### PR TITLE
setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='james.socol@gmail.com',
     url='http://github.com/jsocol/django-waffle',
     license='BSD',
-    packages=['waffle'],
+    packages=['waffle', 'waffle.templatetags'],
     include_package_data=True,
     package_data = { '': ['README.rst'] },
     zip_safe=False,


### PR DESCRIPTION
When installing, the templatetags package was not being installed as it was not included in the packages list.
