### PR TITLE
Changed enable/disable switch functionality in djnago admin

### DIFF
--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -22,12 +22,16 @@ class FlagAdmin(admin.ModelAdmin):
 
 
 def enable_switches(ma, request, qs):
-    qs.update(active=True)
+    for switch in qs:
+        switch.active=True
+        switch.save()
 enable_switches.short_description = 'Enable the selected switches.'
 
 
 def disable_switches(ma, request, qs):
-    qs.update(active=False)
+    for switch in qs:
+        switch.active=False
+        switch.save()
 disable_switches.short_description = 'Disable the selected switches.'
 
 


### PR DESCRIPTION
Previously when I tried to change the status of a switch by using the dropdown menu in the django admin, the switch's status that was displayed changed but the actual functionality of the change was not reflected in the action that I wanted to perform. For instance, I had a switch that controlled sending a specific type of email. I set it originally that the switch was disabled and made it that the email did not send. When I changed the switch to active using the dropdown, which should have allowed the email to be sent, and tried to send the email, the email also did not send. However, when I enabled the switch and then actually saved it in the django admin, by actively calling the save function, the email was sent out properly. This was also true when I disabled the switch.

I changed the code such that on every time the switch was updated in the django admin via the dropdown it actually calls the save function and doesn't just update the queryset. This got rid of the problem and made it so that the email was sent properly when the switch was updated with the dropdown.

Thanks
