### PR TITLE
Add a way to display a template rather than a simple 404

### DIFF
--- a/waffle/decorators.py
+++ b/waffle/decorators.py
@@ -1,12 +1,14 @@
 from functools import wraps
 
 from django.http import Http404
+from django.template import RequestContext
+from django.shortcuts import render_to_response
 from django.utils.decorators import available_attrs
 
 from waffle import flag_is_active, switch_is_active
 
 
-def waffle_flag(flag_name):
+def waffle_flag(flag_name, template_name=None):
     def decorator(view):
         @wraps(view, assigned=available_attrs(view))
         def _wrapped_view(request, *args, **kwargs):
@@ -16,13 +18,17 @@ def waffle_flag(flag_name):
                 active = flag_is_active(request, flag_name)
 
             if not active:
+                if template_name:
+                    return render_to_response(template_name, {
+                       'flag_name': flag_name,
+                    }, context_instance=RequestContext(request))
                 raise Http404
             return view(request, *args, **kwargs)
         return _wrapped_view
     return decorator
 
 
-def waffle_switch(switch_name):
+def waffle_switch(switch_name, template_name=None):
     def decorator(view):
         @wraps(view, assigned=available_attrs(view))
         def _wrapped_view(request, *args, **kwargs):
@@ -32,6 +38,10 @@ def waffle_switch(switch_name):
                 active = switch_is_active(switch_name)
 
             if not active:
+                if template_name:
+                    return render_to_response(template_name, {
+                       'switch_name': switch_name,
+                    }, context_instance=RequestContext(request))
                 raise Http404
             return view(request, *args, **kwargs)
         return _wrapped_view

--- a/waffle/tests/test_decorators.py
+++ b/waffle/tests/test_decorators.py
@@ -32,3 +32,17 @@ class DecoratorTests(TestCase):
         Switch.objects.create(name='foo', active=True)
         resp = self.client.get('/switch-off')
         eq_(404, resp.status_code)
+
+    def test_switch_with_template(self):
+        resp = self.client.get('/switch-off', template="django.html")
+        eq_(200, resp.status_code)
+        Switch.objects.create(name='foo', active=True)
+        resp = self.client.get('/switch-off', tempalte="django.html")
+        eq_(200, resp.status_code)
+
+    def test_flag_with_template(self):
+        resp = self.client.get('/flag-on', template="django.html")
+        eq_(200, resp.status_code)
+        Flag.objects.create(name='foo', everyone=True)
+        resp = self.client.get('/flag-on', template="django.html")
+        eq_(200, resp.status_code)


### PR DESCRIPTION
Since a `404` page is not always friendly when turning off temporarily a feature. 
Maybe, we should be able to change status code too, returning a `503` might be a better choice. 
