### PR TITLE
WaffleNode.render() raises a KeyError if the context doesn't have a 'request' key. It's helpful for that key to be optional so that we can use waffle samples in email templates.

### DIFF
--- a/waffle/templatetags/waffle_tags.py
+++ b/waffle/templatetags/waffle_tags.py
@@ -23,7 +23,7 @@ class WaffleNode(template.Node):
             yield node
 
     def render(self, context):
-        if self.condition(context['request'], self.name):
+        if self.condition(context.get('request'), self.name):
             return self.nodelist_true.render(context)
         return self.nodelist_false.render(context)
 


### PR DESCRIPTION
...mplates that aren't used in an HTTP context (e.g., email).
