### PR TITLE
Sorting by reverse id for easier administration

### DIFF
--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -21,6 +21,7 @@ class FlagAdmin(admin.ModelAdmin):
     list_filter = ('everyone', 'superusers', 'staff', 'authenticated',
                    'created', 'modified')
     raw_id_fields = ('users', 'groups')
+    ordering = ('-id',)
 
 
 def enable_switches(ma, request, qs):
@@ -42,11 +43,13 @@ class SwitchAdmin(admin.ModelAdmin):
     date_hierarchy = 'created'
     list_display = ('name', 'active', 'created', 'modified', 'note')
     list_filter = ('active',)
+    ordering = ('-id',)
 
 
 class SampleAdmin(admin.ModelAdmin):
     date_hierarchy = 'created'
     list_display = ('name', 'percent', 'created', 'modified', 'note')
+    ordering = ('-id',)
 
 
 admin.site.register(Flag, FlagAdmin)


### PR DESCRIPTION
At Yipit we really find this useful as we use waffle switches rather frequently. We care most about the new ones so we just thought this made sense.

I also believe this was the default sort in Django 1.3 but not in 1.4. 
