### PR TITLE
Renames JavaScript functions to *_is_active, avoiding 'switch' #48

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -411,26 +411,29 @@ Once you've loaded the JavaScript, you can use the global ``waffle``
 object.  Just pass in a flag name. As in the Python API, if a flag or
 switch is undefined, it will always be ``false``.
 
+The function names don't match those in Python because 'switch' is a
+reserved word in JavaScript.
+
 ::
 
-    if (waffle.flag('some_flag')) {
+    if (waffle.flag_is_active('some_flag')) {
         // Flag is active.
     } else {
         // Flag is inactive.
     }
 
-    if (waffle.switch('some_switch')) {
+    if (waffle.switch_is_active('some_switch')) {
         // Switch is active.
     } else {
         // Switch is inactive.
     }
 
-    if (waffle.sample('some_sample')) {
+    if (waffle.sample_is_active('some_sample')) {
         // Sample is active.
     } else {
         // Sample is inactive.
     }
 
-``waffle.sample(foo)`` will return the same value *on a given request*
+``waffle.sample_is_active(foo)`` will return the same value *on a given request*
 but that value may not persist across multiple requests.
 

--- a/waffle/templates/waffle/waffle.js
+++ b/waffle/templates/waffle/waffle.js
@@ -9,13 +9,13 @@
         {% for sample, value in samples %}'{{ sample }}': {% if value %}true{% else %}false{% endif %}{% if not forloop.last %},{% endif %}{% endfor %}
         };
     window.waffle = {
-        "flag": function waffle_flag(flag_name) {
+        "flag_is_active": function waffle_flag(flag_name) {
             return !!FLAGS[flag_name];
         },
-        "switch": function waffle_switch(switch_name) {
+        "switch_is_active": function waffle_switch(switch_name) {
             return !!SWITCHES[switch_name];
         },
-        "sample": function waffle_sample(sample_name) {
+        "sample_is_active": function waffle_sample(sample_name) {
             return !!SAMPLES[sample_name];
         }
     };


### PR DESCRIPTION
This is what I'm currently using in production. I imagine you'll need to offer backwards-compatibility as well though. Although people could just add aliases to the functions, I suppose.
