### PR TITLE
Remove the documentation note about Python/JS function names differing

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -411,9 +411,6 @@ Once you've loaded the JavaScript, you can use the global ``waffle``
 object.  Just pass in a flag name. As in the Python API, if a flag or
 switch is undefined, it will always be ``false``.
 
-The function names don't match those in Python because 'switch' is a
-reserved word in JavaScript.
-
 ::
 
     if (waffle.flag_is_active('some_flag')) {

--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -8,7 +8,7 @@ def enable_for_all(ma, request, qs):
     for f in qs.all():
         f.everyone = True
         f.save()
-enable_for_all.short_description = 'Enable selected flags for everyone.'
+enable_for_all.short_description = 'Enable selected flags for everyone'
 
 
 def disable_for_all(ma, request, qs):
@@ -16,7 +16,7 @@ def disable_for_all(ma, request, qs):
     for f in qs.all():
         f.everyone = False
         f.save()
-disable_for_all.short_description = 'Disable selected flags for everyone.'
+disable_for_all.short_description = 'Disable selected flags for everyone'
 
 
 class FlagAdmin(admin.ModelAdmin):
@@ -33,14 +33,14 @@ def enable_switches(ma, request, qs):
     for switch in qs:
         switch.active = True
         switch.save()
-enable_switches.short_description = 'Enable the selected switches.'
+enable_switches.short_description = 'Enable the selected switches'
 
 
 def disable_switches(ma, request, qs):
     for switch in qs:
         switch.active = False
         switch.save()
-disable_switches.short_description = 'Disable the selected switches.'
+disable_switches.short_description = 'Disable the selected switches'
 
 
 class SwitchAdmin(admin.ModelAdmin):

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -39,11 +39,11 @@ class Flag(models.Model):
     rollout = models.BooleanField(default=False, help_text=(
         'Activate roll-out mode?'))
     note = models.TextField(blank=True, help_text=(
-        'Note where this Flag is used.'))
+        'Note where this flag is used.'))
     created = models.DateTimeField(default=datetime.now, db_index=True,
-        help_text=('Date when this Flag was created.'))
+        help_text=('Date when this flag was created.'))
     modified = models.DateTimeField(default=datetime.now, help_text=(
-        'Date when this Flag was last modified.'))
+        'Date when this flag was last modified.'))
 
     def __unicode__(self):
         return self.name
@@ -62,13 +62,13 @@ class Switch(models.Model):
     name = models.CharField(max_length=100, unique=True,
                             help_text='The human/computer readable name.')
     active = models.BooleanField(default=False, help_text=(
-        'Is this flag active?'))
+        'Is this switch active?'))
     note = models.TextField(blank=True, help_text=(
-        'Note where this Switch is used.'))
+        'Note where this switch is used.'))
     created = models.DateTimeField(default=datetime.now, db_index=True,
-        help_text=('Date when this Switch was created.'))
+        help_text=('Date when this switch was created.'))
     modified = models.DateTimeField(default=datetime.now, help_text=(
-        'Date when this Switch was last modified.'))
+        'Date when this switch was last modified.'))
 
     def __unicode__(self):
         return u'%s: %s' % (self.name, 'on' if self.active else 'off')
@@ -78,7 +78,7 @@ class Switch(models.Model):
         super(Switch, self).save(*args, **kwargs)
 
     class Meta:
-        verbose_name_plural = 'Switches'
+        verbose_name_plural = 'switches'
 
 
 class Sample(models.Model):
@@ -91,11 +91,11 @@ class Sample(models.Model):
         'A number between 0.0 and 100.0 to indicate a percentage of the time '
         'this sample will be active.'))
     note = models.TextField(blank=True, help_text=(
-        'Note where this Sample is used.'))
+        'Note where this sample is used.'))
     created = models.DateTimeField(default=datetime.now, db_index=True,
-        help_text=('Date when this Sample was created.'))
+        help_text=('Date when this sample was created.'))
     modified = models.DateTimeField(default=datetime.now, help_text=(
-        'Date when this Sample was last modified.'))
+        'Date when this sample was last modified.'))
 
     def __unicode__(self):
         return self.name

--- a/waffle/templates/waffle/waffle.js
+++ b/waffle/templates/waffle/waffle.js
@@ -9,13 +9,13 @@
         {% for sample, value in samples %}'{{ sample }}': {% if value %}true{% else %}false{% endif %}{% if not forloop.last %},{% endif %}{% endfor %}
         };
     window.waffle = {
-        "flag": function waffle_flag(flag_name) {
+        "flag_is_active": function waffle_flag(flag_name) {
             return !!FLAGS[flag_name];
         },
-        "switch": function waffle_switch(switch_name) {
+        "switch_is_active": function waffle_switch(switch_name) {
             return !!SWITCHES[switch_name];
         },
-        "sample": function waffle_sample(sample_name) {
+        "sample_is_active": function waffle_sample(sample_name) {
             return !!SAMPLES[sample_name];
         }
     };


### PR DESCRIPTION
Because they don't, in fact. That's the Django template tags. My bad.
