### PR TITLE
Re-add note field for flag admin

### DIFF
--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -23,7 +23,7 @@ class FlagAdmin(admin.ModelAdmin):
     actions = [enable_for_all, disable_for_all]
     date_hierarchy = 'created'
     list_display = ('name', 'everyone', 'percent', 'superusers', 'staff',
-                    'authenticated', 'languages')
+                    'authenticated', 'note', 'languages')
     list_filter = ('everyone', 'superusers', 'staff', 'authenticated')
     raw_id_fields = ('users', 'groups')
     ordering = ('-id',)


### PR DESCRIPTION
the note column was removed from admin after a merge conflict. It was originally added here: https://github.com/jsocol/django-waffle/commit/dd7a5699#L0R20 It was accidentally removed here: https://github.com/jsocol/django-waffle/commit/7471bcbc#L2R20 Note that pull request 54 will be a conflict; it changes the order of the note column but that could be applied by hand.
