### PR TITLE
Use only 1 sql statement for group instead of one per flag_group

### DIFF
--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -96,8 +96,9 @@ def flag_is_active(request, flag_name):
     if flag_groups is None:
         flag_groups = flag.groups.all()
         cache_flag(instance=flag)
+    user_groups = user.groups.all()
     for group in flag_groups:
-        if group in user.groups.all():
+        if group in user_groups:
             return True
 
     if flag.percent > 0:


### PR DESCRIPTION
Hi,

This reduces the number of sql statements generated by waffle signifigantly in my environment, where we have a lot of groups. Instead of dozens of these sql statements for every request:

SELECT `auth_user`.`id`, `auth_user`.`username`, `auth_user`.`first_name`, `auth_user`.`last_name`, `auth_user`.`email`, `auth_user`.`password`, `auth_user`.`is_staff`, `auth_user`.`is_active`, `auth_user`.`is_superuser`, `auth_user`.`last_login`, `auth_user`.`date_joined` FROM `auth_user` WHERE `auth_user`.`id` = %s  (23,)

This commit makes it 1.
