### PR TITLE
Custom user compatibility layer for Django 1.5

### DIFF
--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -1,0 +1,10 @@
+import django
+
+__all__ = ['User']
+
+# Django 1.5+ compatibility
+if django.VERSION >= (1, 5):
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+else:
+    from django.contrib.auth.models import User

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -3,8 +3,10 @@ try:
 except ImportError:
     from datetime import datetime
 
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import Group
 from django.db import models
+
+from waffle.compat import User
 
 
 class Flag(models.Model):

--- a/waffle/tests/base.py
+++ b/waffle/tests/base.py
@@ -1,0 +1,10 @@
+from django.test import Client
+
+from test_utils import TestCase as BaseTestCase
+
+
+class TestCase(BaseTestCase):
+    def setUp(self):
+        super(TestCase, self).setUp()
+
+        self.client = Client()

--- a/waffle/tests/test_decorators.py
+++ b/waffle/tests/test_decorators.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_
-from test_utils import TestCase
 
 from waffle.models import Flag, Switch
+from waffle.tests.base import TestCase
 
 
 class DecoratorTests(TestCase):

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -1,7 +1,8 @@
 from django.core.urlresolvers import reverse
 
 from nose.tools import eq_
-from test_utils import TestCase
+
+from waffle.tests.base import TestCase
 
 
 class WaffleViewTests(TestCase):

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -6,12 +6,13 @@ from django.db import connection
 
 import mock
 from nose.tools import eq_
-from test_utils import RequestFactory, TestCase
+from test_utils import RequestFactory
 
 from test_app import views
 import waffle
 from waffle.middleware import WaffleMiddleware
 from waffle.models import Flag, Sample, Switch
+from waffle.tests.base import TestCase
 
 
 def get(**kw):


### PR DESCRIPTION
Hi,

I have added a simple compatibility layer to use the new custom user introduced in Django 1.5.

Quick note: I have also added a TestCase class in **tests/base.py** to provide a default client which is used in your tests, apparently **test_utils.TestCase** redefines **_pre_setup** and does not redeclare a client like [here](https://github.com/django/django/blob/master/django/test/testcases.py#L465).

Let me know if you want further information or elements to include my PR.
