### PR TITLE
Add active_(flags|switches|samples) functions to wafflejs - #81

### DIFF
--- a/waffle/templates/waffle/waffle.js
+++ b/waffle/templates/waffle/waffle.js
@@ -26,6 +26,33 @@
         if(SAMPLES[sample_name] === undefined) return true;
       {% endif %}
       return !!SAMPLES[sample_name];
+    },
+    "active_flags": function waffle_active_flags() {
+        names = [];
+        for (name in FLAGS) {
+            if (!!FLAGS[name]) {
+                names.push(name);
+            }
+        }
+        return names;
+    },
+    "active_switches": function waffle_active_switches() {
+        names = [];
+        for (name in SWITCHES) {
+            if (!!SWITCHES[name]) {
+                names.push(name);
+            }
+        }
+        return names;
+    },
+    "active_samples": function waffle_active_samples() {
+        names = [];
+        for (name in SAMPLES) {
+            if (!!SAMPLES[name]) {
+                names.push(name);
+            }
+        }
+        return names;
     }
   };
 })();


### PR DESCRIPTION
Each function returns a list of the names of active items.

Note: Does not take into account the values of `flag_default`, `switch_default`, or `sample_default`.
