### PR TITLE
Fix caching/invalidation of 'all' lists

### DIFF
--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse
 
 from nose.tools import eq_
 
+from waffle.models import Flag, Sample, Switch
 from waffle.tests.base import TestCase
 
 
@@ -11,3 +12,42 @@ class WaffleViewTests(TestCase):
         eq_(200, response.status_code)
         eq_('application/x-javascript', response['content-type'])
         eq_('max-age=0', response['cache-control'])
+
+    def test_flush_all_flags(self):
+        """Test the 'FLAGS_ALL' list gets invalidated correctly."""
+        Flag.objects.create(name='myflag1', everyone=True)
+        response = self.client.get(reverse('wafflejs'))
+        eq_(200, response.status_code)
+        assert ('myflag1', True) in response.context['flags']
+
+        Flag.objects.create(name='myflag2', everyone=True)
+
+        response = self.client.get(reverse('wafflejs'))
+        eq_(200, response.status_code)
+        assert ('myflag2', True) in response.context['flags']
+
+    def test_flush_all_switches(self):
+        """Test the 'SWITCHES_ALL' list gets invalidated correctly."""
+        switch = Switch.objects.create(name='myswitch', active=True)
+        response = self.client.get(reverse('wafflejs'))
+        eq_(200, response.status_code)
+        assert ('myswitch', True) in response.context['switches']
+
+        switch.active = False
+        switch.save()
+        response = self.client.get(reverse('wafflejs'))
+        eq_(200, response.status_code)
+        assert ('myswitch', False) in response.context['switches']
+
+    def test_flush_all_samples(self):
+        """Test the 'SAMPLES_ALL' list gets invalidates correctly."""
+        Sample.objects.create(name='sample1', percent='100.0')
+        response = self.client.get(reverse('wafflejs'))
+        eq_(200, response.status_code)
+        assert ('sample1', True) in response.context['samples']
+
+        Sample.objects.create(name='sample2', percent='100.0')
+
+        response = self.client.get(reverse('wafflejs'))
+        eq_(200, response.status_code)
+        assert ('sample2', True) in response.context['samples']

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -40,7 +40,7 @@ class WaffleViewTests(TestCase):
         assert ('myswitch', False) in response.context['switches']
 
     def test_flush_all_samples(self):
-        """Test the 'SAMPLES_ALL' list gets invalidates correctly."""
+        """Test the 'SAMPLES_ALL' list gets invalidated correctly."""
         Sample.objects.create(name='sample1', percent='100.0')
         response = self.client.get(reverse('wafflejs'))
         eq_(200, response.status_code)

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -2,29 +2,30 @@ from django.core.cache import cache
 from django.shortcuts import render_to_response
 from django.views.decorators.cache import never_cache
 
-from waffle import (flag_is_active, sample_is_active, FLAGS_ALL_CACHE_KEY,
-                    SWITCHES_ALL_CACHE_KEY, SAMPLES_ALL_CACHE_KEY)
+from waffle import (keyfmt, flag_is_active, sample_is_active,
+                    FLAGS_ALL_CACHE_KEY, SWITCHES_ALL_CACHE_KEY,
+                    SAMPLES_ALL_CACHE_KEY)
 from waffle.models import Flag, Sample, Switch
 from django.conf import settings
 
 
 @never_cache
 def wafflejs(request):
-    flags = cache.get(FLAGS_ALL_CACHE_KEY)
+    flags = cache.get(keyfmt(FLAGS_ALL_CACHE_KEY))
     if not flags:
         flags = Flag.objects.values_list('name', flat=True)
-        cache.add(FLAGS_ALL_CACHE_KEY, flags)
+        cache.add(keyfmt(FLAGS_ALL_CACHE_KEY), flags)
     flag_values = [(f, flag_is_active(request, f)) for f in flags]
 
-    switches = cache.get(SWITCHES_ALL_CACHE_KEY)
+    switches = cache.get(keyfmt(SWITCHES_ALL_CACHE_KEY))
     if not switches:
         switches = Switch.objects.values_list('name', 'active')
-        cache.add(SWITCHES_ALL_CACHE_KEY, switches)
+        cache.add(keyfmt(SWITCHES_ALL_CACHE_KEY), switches)
 
-    samples = cache.get(SAMPLES_ALL_CACHE_KEY)
+    samples = cache.get(keyfmt(SAMPLES_ALL_CACHE_KEY))
     if not samples:
         samples = Sample.objects.values_list('name', flat=True)
-        cache.add(SAMPLES_ALL_CACHE_KEY, samples)
+        cache.add(keyfmt(SAMPLES_ALL_CACHE_KEY), samples)
     sample_values = [(s, sample_is_active(s)) for s in samples]
 
     flag_default = getattr(settings, 'WAFFLE_FLAG_DEFAULT', False)


### PR DESCRIPTION
The wafflejs view wasn't storing the ALL lists using keyfmt(), so the post_save/post_delete signals that were using keyfmt weren't invalidating the cache.
