### PR TITLE
Update South migrations to use timezone aware datetime objects.

### DIFF
--- a/waffle/migrations/0005_auto__add_field_flag_created__add_field_flag_modified.py
+++ b/waffle/migrations/0005_auto__add_field_flag_created__add_field_flag_modified.py
@@ -4,15 +4,23 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
+try:
+    from django.utils.timezone import now
+except ImportError:
+    now = datetime.datetime.now
+
+default_datetime = now()
+
+
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
         
         # Adding field 'Flag.created'
-        db.add_column('waffle_flag', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=datetime.datetime(2011, 12, 7, 10, 19, 18, 930661), db_index=True, blank=True), keep_default=False)
+        db.add_column('waffle_flag', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=default_datetime, db_index=True, blank=True), keep_default=False)
 
         # Adding field 'Flag.modified'
-        db.add_column('waffle_flag', 'modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, default=datetime.datetime(2011, 12, 7, 10, 19, 27, 811182), blank=True), keep_default=False)
+        db.add_column('waffle_flag', 'modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, default=default_datetime, blank=True), keep_default=False)
 
 
     def backwards(self, orm):

--- a/waffle/migrations/0006_auto__add_field_switch_created__add_field_switch_modified__add_field_s.py
+++ b/waffle/migrations/0006_auto__add_field_switch_created__add_field_switch_modified__add_field_s.py
@@ -4,21 +4,29 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
+try:
+    from django.utils.timezone import now
+except ImportError:
+    now = datetime.datetime.now
+
+default_datetime = now()
+
+
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
         
         # Adding field 'Switch.created'
-        db.add_column('waffle_switch', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=datetime.datetime(2011, 12, 7, 10, 23, 1, 941441), db_index=True, blank=True), keep_default=False)
+        db.add_column('waffle_switch', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=default_datetime, db_index=True, blank=True), keep_default=False)
 
         # Adding field 'Switch.modified'
-        db.add_column('waffle_switch', 'modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, default=datetime.datetime(2011, 12, 7, 10, 23, 6, 813869), blank=True), keep_default=False)
+        db.add_column('waffle_switch', 'modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, default=default_datetime, blank=True), keep_default=False)
 
         # Adding field 'Sample.created'
-        db.add_column('waffle_sample', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=datetime.datetime(2011, 12, 7, 10, 23, 12, 445207), db_index=True, blank=True), keep_default=False)
+        db.add_column('waffle_sample', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=default_datetime, db_index=True, blank=True), keep_default=False)
 
         # Adding field 'Sample.modified'
-        db.add_column('waffle_sample', 'modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, default=datetime.datetime(2011, 12, 7, 10, 23, 18, 101189), blank=True), keep_default=False)
+        db.add_column('waffle_sample', 'modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, default=default_datetime, blank=True), keep_default=False)
 
 
     def backwards(self, orm):


### PR DESCRIPTION
Currently waffle migrations use native datetime objects for default datetime field values. This means applying migrations will fail if you have `USE_TZ` set to `True`.

I've modified migrations which specify default value for datetime fields to use timezone aware datetime object with a value of now.

This is fully backward compatible since `django.utils.timezone.now` simply returns a naive datetime object if `USE_TZ` is set to `False`. For older versions which don't include `django.utils.timezone.now` function, it simply falls back to `datetime.datetime.now`.

For example:

``` python
FailedDryRun:  ! Error found during dry run of '0005_auto__add_field_flag_created__add_field_flag_modified'! Aborting.
Traceback (most recent call last):
  File "/home/foo/.virtualenvs/venv1/local/lib/python2.7/site-packages/south/migration/migrators.py", line 173, in _run_migration
    migration_function()
  File "/home/foo/.virtualenvs/venv1/local/lib/python2.7/site-packages/south/migration/migrators.py", line 62, in <lambda>
    return (lambda: direction(orm))
  File "/home/foo/.virtualenvs/venv1/local/lib/python2.7/site-packages/waffle/migrations/0005_auto__add_field_flag_created__add_field_flag_modified.py", line 12, in forwards
    db.add_column('waffle_flag', 'created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=datetime.datetime(2011, 12, 7, 10, 19, 18, 930661), db_index=True, blank=True), keep_default=False)
  File "/home/foo/.virtualenvs/venv1/local/lib/python2.7/site-packages/south/db/sqlite3.py", line 35, in add_column
    field_default = "'%s'" % field.get_db_prep_save(default, connection=self._get_connection())
  File "/home/foo/.virtualenvs/venv1/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 304, in get_db_prep_save
    prepared=False)
  File "/home/foo/.virtualenvs/venv1/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 835, in get_db_prep_value
    value = self.get_prep_value(value)
  File "/home/foo/.virtualenvs/venv1/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 827, in get_prep_value
    RuntimeWarning)
RuntimeWarning: DateTimeField received a naive datetime (2011-12-07 10:19:18.930661) while time zone support is active.
```
