### PR TITLE
Fix Django 1.5 User model importing

### DIFF
--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -4,7 +4,7 @@ __all__ = ['User']
 
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
+    from django.conf import settings
+    User = settings.AUTH_USER_MODEL
 else:
     from django.contrib.auth.models import User

--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -1,10 +1,10 @@
 import django
 
-__all__ = ['User']
+__all__ = ['AUTH_USER_MODEL']
 
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):
     from django.conf import settings
-    User = settings.AUTH_USER_MODEL
+    AUTH_USER_MODEL = settings.AUTH_USER_MODEL
 else:
-    from django.contrib.auth.models import User
+    AUTH_USER_MODEL = 'auth.User'

--- a/waffle/migrations/0001_initial.py
+++ b/waffle/migrations/0001_initial.py
@@ -3,7 +3,7 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
-from waffle.compat import User
+from waffle.compat import AUTH_USER_MODEL
 
 class Migration(SchemaMigration):
 
@@ -34,7 +34,7 @@ class Migration(SchemaMigration):
         db.create_table('waffle_flag_users', (
             ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
             ('flag', models.ForeignKey(orm['waffle.flag'], null=False)),
-            ('user', models.ForeignKey(User, null=False))
+            ('user', models.ForeignKey(orm[AUTH_USER_MODEL], null=False))
         ))
         db.create_unique('waffle_flag_users', ['flag_id', 'user_id'])
 

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -6,7 +6,7 @@ except ImportError:
 from django.contrib.auth.models import Group
 from django.db import models
 
-from waffle.compat import User
+from waffle.compat import AUTH_USER_MODEL
 
 
 class Flag(models.Model):
@@ -37,7 +37,7 @@ class Flag(models.Model):
         'separated list)'))
     groups = models.ManyToManyField(Group, blank=True, help_text=(
         'Activate this flag for these user groups.'))
-    users = models.ManyToManyField(User, blank=True, help_text=(
+    users = models.ManyToManyField(AUTH_USER_MODEL, blank=True, help_text=(
         'Activate this flag for these users.'))
     rollout = models.BooleanField(default=False, help_text=(
         'Activate roll-out mode?'))


### PR DESCRIPTION
I get a circular import problem in my Django 1.5 app caused by waffle getting the user model incorrectly.

From the [docs](https://docs.djangoproject.com/en/1.5/topics/auth/customizing/#django.contrib.auth.get_user_model):

> When you define a foreign key or many-to-many relations to the User model, you should specify the custom model using the AUTH_USER_MODEL setting.

`waffle.compat.User` is used to define a `ManyToManyField`.
