### PR TITLE
Make --list option more verbose

### DIFF
--- a/waffle/management/commands/flag.py
+++ b/waffle/management/commands/flag.py
@@ -62,7 +62,14 @@ class Command(BaseCommand):
         if list_flag:
             print "Flags:"
             for flag in Flag.objects.iterator():
-                print "%s" % (flag.name)
+                print "\nNAME: %s" % (flag.name)
+                print "SUPERUSERS: %s" % (flag.superusers)
+                print "EVERYONE: %s" % (flag.everyone)
+                print "AUTHENTICATED: %s" % (flag.authenticated)
+                print "PERCENT: %s" % (flag.percent)
+                print "TESTING: %s" % (flag.testing)
+                print "ROLLOUT: %s" % (flag.rollout)
+                print "STAFF: %s" % (flag.staff)
             return
 
         if not flag_name:

--- a/waffle/templates/waffle/waffle.js
+++ b/waffle/templates/waffle/waffle.js
@@ -9,6 +9,9 @@
     {% for sample, value in samples %}'{{ sample }}': {% if value %}true{% else %}false{% endif %}{% if not forloop.last %},{% endif %}{% endfor %}
     };
   window.waffle = {
+    "get_flags": function get_flags() {
+      return FLAGS;
+    },
     "flag_is_active": function waffle_flag(flag_name) {
       {% if flag_default %}
         if(FLAGS[flag_name] === undefined) return true;


### PR DESCRIPTION
The --list option doesn't seem to be verbose enough. It would be nice to see more than just a name when listing each flag. This small addition displays other interesting fields for each flag when they're listed.
