### PR TITLE
fix south migration on django 1.5, fixes #88

### DIFF
--- a/waffle/migrations/0001_initial.py
+++ b/waffle/migrations/0001_initial.py
@@ -3,6 +3,7 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+from waffle.compat import User
 
 class Migration(SchemaMigration):
 
@@ -33,7 +34,7 @@ class Migration(SchemaMigration):
         db.create_table('waffle_flag_users', (
             ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
             ('flag', models.ForeignKey(orm['waffle.flag'], null=False)),
-            ('user', models.ForeignKey(orm['auth.user'], null=False))
+            ('user', models.ForeignKey(User, null=False))
         ))
         db.create_unique('waffle_flag_users', ['flag_id', 'user_id'])
 


### PR DESCRIPTION
Fixes the south migration 0001 by using `waffle.compat.User` instead of `orm['auth.user']`
