### PR TITLE
mimetype -> content_type

### DIFF
--- a/waffle/views.py
+++ b/waffle/views.py
@@ -41,4 +41,4 @@ def wafflejs(request):
                                 'switch_default': switch_default,
                                 'sample_default': sample_default,
                               },
-                              mimetype='application/x-javascript')
+                              content_type='application/x-javascript')


### PR DESCRIPTION
Accoding to Django documentation, `mimetype` is long deprecated and should have been replaced by `content_type` long ago.
