### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
- - "2.6"
- - "2.7"
- - "3.3"
+ - 2.6
+ - 2.7
+ - 3.3
 env:
  - DJANGO_VERSION=1.4.9
  - DJANGO_VERSION=1.5.5
@@ -12,4 +12,4 @@ script: invoke test
 matrix:
   exclude:
     - python: 3.3
-      env: DJANGO=1.4.9
+      env: DJANGO_VERSION=1.4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: python
 python:
  - "2.6"
  - "2.7"
+ - "3.3"
 env:
- - DJANGO_VERSION=1.4.8
- - DJANGO_VERSION=1.5.4
+ - DJANGO_VERSION=1.4.9
+ - DJANGO_VERSION=1.5.5
 install:
  - pip install -q Django==${DJANGO_VERSION} -r travis.txt --use-mirrors
-script: fab test
+script: invoke test
+matrix:
+  exclude:
+    - python: 3.3
+      env: DJANGO=1.4.9

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -23,9 +23,9 @@ Done!
 Running Things
 ==============
 
-Running Django apps without a Django project is a pain, so we use Fabric to
-pave over all that. Almost everything runs through ``fab``. To see a list of
-the commands, run ``fab -l``::
+Running Django apps without a Django project is a pain, so we use invoke to
+pave over all that. Almost everything runs through ``invoke``. To see a list of
+the commands, run ``invoke -l``::
 
     Available commands:
 
@@ -36,11 +36,11 @@ the commands, run ``fab -l``::
         syncdb   Create a database for testing in the shell or server.
         test     Run the Waffle test suite.
 
-To run the tests, just run ``fab test``.
+To run the tests, just run ``invoke test``.
 
-To manually test out the app and admin, you'll want to run ``fab syncdb`` then
-``fab migrate``, then you can run ``fab serve`` to start the Django dev server,
-or ``fab shell`` to open the Django shell.
+To manually test out the app and admin, you'll want to run ``invoke syncdb`` then
+``invoke migrate``, then you can run ``invoke serve`` to start the Django dev server,
+or ``invoke shell`` to open the Django shell.
 
 
 Writing Patches

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/tasks.py
+++ b/tasks.py
@@ -4,10 +4,8 @@ you don't have a settings.py file.  I can never remember to define
 DJANGO_SETTINGS_MODULE, so I run these commands which get the right env
 automatically.
 """
-import functools
 import os
-
-from fabric.api import local as _local
+from invoke import run, task
 
 
 NAME = os.path.basename(os.path.dirname(__file__))
@@ -17,34 +15,38 @@ os.environ['DJANGO_SETTINGS_MODULE'] = '%s-project.settings' % NAME
 os.environ['PYTHONPATH'] = os.pathsep.join([ROOT,
                                             os.path.join(ROOT, 'examples')])
 
-_local = functools.partial(_local, capture=False)
 
-
+@task
 def shell():
     """Start a Django shell with the test settings."""
-    _local('django-admin.py shell')
+    run('django-admin.py shell')
 
 
+@task
 def test():
     """Run the Waffle test suite."""
-    _local('django-admin.py test')
+    run('django-admin.py test')
 
 
+@task
 def serve():
     """Start the Django dev server."""
-    _local('django-admin.py runserver')
+    run('django-admin.py runserver')
 
 
+@task
 def syncdb():
     """Create a database for testing in the shell or server."""
-    _local('django-admin.py syncdb')
+    run('django-admin.py syncdb')
 
 
+@task
 def schema():
     """Create a schema migration for any changes."""
-    _local('django-admin.py schemamigration waffle --auto')
+    run('django-admin.py schemamigration waffle --auto')
 
 
+@task
 def migrate():
     """Update a testing database with south."""
-    _local('django-admin.py migrate')
+    run('django-admin.py migrate')

--- a/tasks.py
+++ b/tasks.py
@@ -25,7 +25,7 @@ def shell():
 @task
 def test():
     """Run the Waffle test suite."""
-    run('django-admin.py test')
+    run('django-admin.py test', pty=True)
 
 
 @task

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,9 +1,8 @@
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render_to_response, render
 from django.template import Context, RequestContext
 from django.template.loader import render_to_string
 
-import jingo
 from waffle import flag_is_active
 from waffle.decorators import waffle_flag, waffle_switch
 
@@ -15,7 +14,7 @@ def flag_in_view(request):
 
 
 def flag_in_jingo(request):
-    return jingo.render(request, 'jingo.html')
+    return render(request, 'jingo.html')
 
 
 def flag_in_django(request):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,46 @@
+[tox]
+envlist = py2.6-django1.4.X, py2.7-django1.4.X, py2.6-django1.5.X, py2.7-django1.5.X, py2.6-django1.6.X,
+          py2.7-django1.6.X, py3.3-django1.5.X, py3.3-django1.6.X
+
+[testenv]
+commands=fab test
+
+[testenv:py2.6-django1.4.X]
+basepython = python2.6
+deps = Django>=1.4,<1.5
+       -rtravis.txt
+
+[testenv:py2.7-django1.4.X]
+basepython = python2.7
+deps = Django>=1.4,<1.5
+       -rtravis.txt
+
+[testenv:py2.6-django1.5.X]
+basepython = python2.6
+deps = Django>=1.5,<1.6
+       -rtravis.txt
+
+[testenv:py2.7-django1.5.X]
+basepython = python2.7
+deps = Django>=1.5,<1.6
+       -rtravis.txt
+
+[testenv:py2.6-django1.6.X]
+basepython = python2.6
+deps = https://www.djangoproject.com/download/1.6c1/tarball/
+       -rtravis.txt
+
+[testenv:py2.7-django1.6.X]
+basepython = python2.7
+deps = https://www.djangoproject.com/download/1.6c1/tarball/
+       -rtravis.txt
+
+[testenv:py3.3-django1.5.X]
+basepython = python3.3
+deps = Django>=1.5,<1.6
+       -rtravis.txt
+
+[testenv:py3.3-django1.6.X]
+basepython = python3.3
+deps = https://www.djangoproject.com/download/1.6c1/tarball/
+       -rtravis.txt

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py2.6-django1.4.X, py2.7-django1.4.X, py2.6-django1.5.X, py2.7-django1
           py2.7-django1.6.X, py3.3-django1.5.X, py3.3-django1.6.X
 
 [testenv]
-commands=fab test
+commands=invoke test
 
 [testenv:py2.6-django1.4.X]
 basepython = python2.6

--- a/travis.txt
+++ b/travis.txt
@@ -2,7 +2,7 @@
 # versions.
 nose==1.1.2
 mock==1.0b1
-fabric==1.4.3
+invoke==0.5.1
 Jinja2>=2.6
 south==0.7.6
 -e git+git://github.com/jbalogh/test-utils.git@3c2214d193d#egg=test-utils

--- a/travis.txt
+++ b/travis.txt
@@ -8,4 +8,3 @@ south==0.7.6
 -e git+git://github.com/jbalogh/test-utils.git@3c2214d193d#egg=test-utils
 -e git+git://github.com/jbalogh/django-nose.git@e3942c2c9d91267#egg=django-nose
 -e git+git://github.com/jbalogh/jingo.git@1dc0e0bf4a0118#egg=jingo
-

--- a/travis.txt
+++ b/travis.txt
@@ -5,6 +5,5 @@ mock==1.0b1
 invoke==0.5.1
 Jinja2>=2.6
 South==dev
--e git+git://github.com/jbalogh/test-utils.git@3c2214d193d#egg=test-utils
 django-nose==1.2
 -e git+git://github.com/jbalogh/jingo.git@3b64b768#egg=jingo

--- a/travis.txt
+++ b/travis.txt
@@ -4,7 +4,7 @@ nose==1.1.2
 mock==1.0b1
 invoke==0.5.1
 Jinja2>=2.6
-south==0.7.6
+South==dev
 -e git+git://github.com/jbalogh/test-utils.git@3c2214d193d#egg=test-utils
--e git+git://github.com/jbalogh/django-nose.git@e3942c2c9d91267#egg=django-nose
--e git+git://github.com/jbalogh/jingo.git@1dc0e0bf4a0118#egg=jingo
+django-nose==1.2
+-e git+git://github.com/jbalogh/jingo.git@3b64b768#egg=jingo

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -5,6 +5,7 @@ import hashlib
 from django.conf import settings
 from django.core.cache import cache
 from django.db.models.signals import post_save, post_delete, m2m_changed
+from django.utils.encoding import smart_bytes
 
 from waffle.models import Flag, Sample, Switch
 
@@ -29,7 +30,7 @@ TEST_COOKIE_NAME = getattr(settings, 'WAFFLE_TESTING_COOKIE', 'dwft_%s')
 def keyfmt(k, v=None):
     if v is None:
         return CACHE_PREFIX + k
-    return CACHE_PREFIX + hashlib.md5(k % v).hexdigest()
+    return CACHE_PREFIX + hashlib.md5(smart_bytes(k % v)).hexdigest()
 
 
 class DoesNotExist(object):
@@ -108,7 +109,7 @@ def flag_is_active(request, flag_name):
         if group in user_groups:
             return True
 
-    if flag.percent > 0:
+    if flag.percent and flag.percent > 0:
         if not hasattr(request, 'waffles'):
             request.waffles = {}
         elif flag_name in request.waffles:

--- a/waffle/tests/base.py
+++ b/waffle/tests/base.py
@@ -1,10 +1,9 @@
-from django.test import Client
+from django import test
+from django.core import cache
 
-from test_utils import TestCase as BaseTestCase
 
+class TestCase(test.TransactionTestCase):
 
-class TestCase(BaseTestCase):
-    def setUp(self):
-        super(TestCase, self).setUp()
-
-        self.client = Client()
+    def _pre_setup(self):
+        cache.cache.clear()
+        super(TestCase, self)._pre_setup()

--- a/waffle/tests/test_middleware.py
+++ b/waffle/tests/test_middleware.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
+from django.test import RequestFactory
 
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 from waffle.middleware import WaffleMiddleware
 

--- a/waffle/tests/test_templates.py
+++ b/waffle/tests/test_templates.py
@@ -1,5 +1,8 @@
+from django import template
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
+from django.test.utils import override_settings
+import mock
 
 from test_app import views
 from waffle.middleware import WaffleMiddleware
@@ -18,6 +21,7 @@ def process_request(request, view):
 
 
 class WaffleTemplateTests(TestCase):
+
     def test_django_tags(self):
         request = get()
         response = process_request(request, views.flag_in_django)
@@ -35,7 +39,19 @@ class WaffleTemplateTests(TestCase):
         assert 'switch off' in content
         assert 'sample' in content
 
+    @override_settings(TEMPLATE_LOADERS=(
+        'jingo.Loader',
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    ))
+    @mock.patch.object(template.loader, 'template_source_loaders', None)
     def test_jingo_tags(self):
+        """
+            We're manually changing default TEMPLATE_LOADERS to enable jingo
+
+            template_source_loaders needs to be patched to None, otherwise
+            TEMPLATE_LOADERS won't be overriden.
+        """
         request = get()
         response = process_request(request, views.flag_in_jingo)
         self.assertContains(response, 'flag off')

--- a/waffle/tests/test_templates.py
+++ b/waffle/tests/test_templates.py
@@ -1,9 +1,9 @@
 from django.contrib.auth.models import AnonymousUser
-
-from test_utils import RequestFactory, TestCase
+from django.test import RequestFactory
 
 from test_app import views
 from waffle.middleware import WaffleMiddleware
+from waffle.tests.base import TestCase
 
 
 def get():

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -34,7 +34,7 @@ class WaffleTests(TestCase):
         # Flag stays on.
         request.COOKIES['dwf_myflag'] = 'True'
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert 'dwf_myflag' in response.cookies
         eq_('True', response.cookies['dwf_myflag'].value)
 
@@ -45,7 +45,7 @@ class WaffleTests(TestCase):
         # Flag stays off.
         request.COOKIES['dwf_myflag'] = 'False'
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert 'dwf_myflag' in response.cookies
         eq_('False', response.cookies['dwf_myflag'].value)
 
@@ -61,20 +61,20 @@ class WaffleTests(TestCase):
         Flag.objects.create(name='myflag', superusers=True)
         request = get()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         superuser = User(username='foo', is_superuser=True)
         request.user = superuser
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         non_superuser = User(username='bar', is_superuser=False)
         non_superuser.save()
         request.user = non_superuser
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_staff(self):
@@ -82,35 +82,35 @@ class WaffleTests(TestCase):
         Flag.objects.create(name='myflag', staff=True)
         request = get()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         staff = User(username='foo', is_staff=True)
         request.user = staff
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         non_staff = User(username='foo', is_staff=False)
         non_staff.save()
         request.user = non_staff
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_languages(self):
         Flag.objects.create(name='myflag', languages='en,fr')
         request = get()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
 
         request.LANGUAGE_CODE = 'en'
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
 
         request.LANGUAGE_CODE = 'de'
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
 
     def test_user(self):
         """Test the per-user switch."""
@@ -121,12 +121,12 @@ class WaffleTests(TestCase):
         request = get()
         request.user = user
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User.objects.create(username='someone_else')
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_group(self):
@@ -141,13 +141,13 @@ class WaffleTests(TestCase):
         request = get()
         request.user = user
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User(username='someone_else')
         request.user.save()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_authenticated(self):
@@ -156,13 +156,13 @@ class WaffleTests(TestCase):
 
         request = get()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User(username='foo')
         assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_everyone_on(self):
@@ -172,13 +172,13 @@ class WaffleTests(TestCase):
         request = get()
         request.COOKIES['dwf_myflag'] = 'False'
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User(username='foo')
         assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_everyone_off(self):
@@ -189,13 +189,13 @@ class WaffleTests(TestCase):
         request = get()
         request.COOKIES['dwf_myflag'] = 'True'
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User(username='foo')
         assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_percent(self):
@@ -266,19 +266,19 @@ class WaffleTests(TestCase):
     def test_set_then_unset_testing_flag(self):
         Flag.objects.create(name='myflag', testing=True)
         response = self.client.get('/flag_in_view?dwft_myflag=1')
-        eq_('on', response.content)
+        eq_(b'on', response.content)
 
         response = self.client.get('/flag_in_view')
-        eq_('on', response.content)
+        eq_(b'on', response.content)
 
         response = self.client.get('/flag_in_view?dwft_myflag=0')
-        eq_('off', response.content)
+        eq_(b'off', response.content)
 
         response = self.client.get('/flag_in_view')
-        eq_('off', response.content)
+        eq_(b'off', response.content)
 
         response = self.client.get('/flag_in_view?dwft_myflag=1')
-        eq_('on', response.content)
+        eq_(b'on', response.content)
 
 
 class SwitchTests(TestCase):

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -3,10 +3,10 @@ import random
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.db import connection
+from django.test import RequestFactory
 
 import mock
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 from test_app import views
 import waffle


### PR DESCRIPTION
Adding python 3.3 support to waffle. 

Due to Fabric still lacking py3 support, I dared to switch Fabric to `invoke` (which is Fabric successor of some kind).
