### PR TITLE
[Feature Proposal] Adding FLAGS, SWITCHES, SAMPLES to window.waffle.

### DIFF
--- a/waffle/templates/waffle/waffle.js
+++ b/waffle/templates/waffle/waffle.js
@@ -29,6 +29,9 @@
         if(SAMPLES[sample_name] === undefined) return true;
       {% endif %}
       return !!SAMPLES[sample_name];
-    }
+    },
+    "FLAGS": FLAGS,
+    "SWITCHES": SWITCHES,
+    "SAMPLES": SAMPLES
   };
 })();


### PR DESCRIPTION
# Use Case

We have some JavaScript for other services (Qualaroo, Optimizely, etc) that allow us to pass additional metadata. Specifically, we only want to target certain people/groups and to do this, we need to query the flags/switches for a given user.
## Problem

Having the waffle methods isn't enough to be useful as we need to pass raw flag values to the external services so that another person/team in our organization can use the flag names as logic.

We don't want to have to query all the flags/switches/samples for users on our backend and pass it through (possibly in a context processor) as we have quite a few flags/switches and we want to query them as little as possible (for performance reasons).
## Solution

Expose `FLAGS`, `SWITCHES`, and `SAMPLES` objects on `window.waffle`.
## Concerns

I wasn't sure why these raw values weren't exposed -- I thought it may be to discourage people trying to set values (thinking that it would set it on the server) but I'm not sure. If that is the case, I could wrap the objects in a getter and have it return a new object (so that trying to set the values doesn't actually do anything).
