### PR TITLE
create a wafflejs helper to include without HTTP request

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -297,8 +297,14 @@ Rollout Mode is enabled **per flag**.
 Waffle in JavaScript
 ====================
 
-Waffle now helps you use flags directly in JavaScript. You need to add
-the Waffle URLs to your URL config::
+Waffle now helps you use flags directly in JavaScript. You can create a global
+``waffle`` object for your JavaScript with either the ``wafflejs`` view, or the
+``wafflejs`` template tag (django) or helper (jinja).
+
+wafflejs view
+-------------
+To use the ``wafflejs`` view, You need to add the Waffle URLs to your URL 
+config::
 
     urlpatterns = patterns('',
         # ...
@@ -310,6 +316,34 @@ This adds a named URL route called ``wafflejs``. You can then load the
 Waffle JavaScript in your templates::
 
     <script src="{% url wafflejs %}"></script>
+
+wafflejs tag/helper
+-------------------
+
+To use the tag or helper, simply call it from within a ``<script>`` block in a 
+template. This removes an extra HTTP request for the ``wafflejs`` resource.
+
+Django tag::
+
+    <script type="text/javascript">
+    {% wafflejs %}
+    </script>
+
+Jinja helper::
+
+    <script type="text/javascript">
+    {{ waffle.wafflejs() }}
+    </script>
+
+If using Jingo_, you need to add ``waffle`` to your ``JINGO_EXCLUDE_APPS``
+for the ``waffle.js`` template to render.::
+
+   JINGO_EXCLUDE_APPS = (
+       'waffle',
+   )
+
+Use the waffle object
+---------------------
 
 Once you've loaded the JavaScript, you can use the global ``waffle``
 object.  Just pass in a flag name. As in the Python API, if a flag or

--- a/test_app/templates/django.html
+++ b/test_app/templates/django.html
@@ -39,3 +39,5 @@
 {% else %}
   sample_var off
 {% endsample %}
+
+{% wafflejs %}

--- a/test_app/templates/jingo.html
+++ b/test_app/templates/jingo.html
@@ -15,3 +15,5 @@
 {% else %}
   sample off
 {% endif %}
+
+{{ waffle.wafflejs() }}

--- a/waffle/helpers.py
+++ b/waffle/helpers.py
@@ -2,6 +2,7 @@ import jingo
 import jinja2
 
 from waffle import flag_is_active, sample_is_active, switch_is_active
+from waffle.views import _generate_waffle_js
 
 
 @jinja2.contextfunction
@@ -9,8 +10,14 @@ def flag_helper(context, flag_name):
     return flag_is_active(context['request'], flag_name)
 
 
+@jinja2.contextfunction
+def inline_wafflejs_helper(context):
+    return _generate_waffle_js(context['request'])
+
+
 jingo.env.globals['waffle'] = {
     'flag': flag_helper,
     'switch': switch_is_active,
     'sample': sample_is_active,
+    'wafflejs': inline_wafflejs_helper
 }

--- a/waffle/templatetags/waffle_tags.py
+++ b/waffle/templatetags/waffle_tags.py
@@ -2,6 +2,7 @@ from django import template
 from django.template.base import VariableDoesNotExist
 
 from waffle import flag_is_active, sample_is_active, switch_is_active
+from waffle.views import _generate_waffle_js
 
 
 register = template.Library()
@@ -73,3 +74,13 @@ def switch(parser, token):
 def sample(parser, token):
     condition = lambda request, name: sample_is_active(name)
     return WaffleNode.handle_token(parser, token, 'sample', condition)
+
+
+class InlineWaffleJSNode(template.Node):
+    def render(self, context):
+        return _generate_waffle_js(context['request'])
+
+
+@register.tag
+def wafflejs(parser, token):
+    return InlineWaffleJSNode()

--- a/waffle/tests/test_templates.py
+++ b/waffle/tests/test_templates.py
@@ -27,6 +27,7 @@ class WaffleTemplateTests(TestCase):
         self.assertContains(response, 'flag_var off')
         self.assertContains(response, 'switch_var off')
         self.assertContains(response, 'sample_var')
+        self.assertContains(response, 'window.waffle =')
 
     def test_no_request_context(self):
         """Switches and Samples shouldn't require a request context."""
@@ -41,3 +42,4 @@ class WaffleTemplateTests(TestCase):
         self.assertContains(response, 'flag off')
         self.assertContains(response, 'switch off')
         self.assertContains(response, 'sample')
+        self.assertContains(response, 'window.waffle =')

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -1,5 +1,6 @@
 from django.core.cache import cache
-from django.shortcuts import render_to_response
+from django.http import HttpResponse
+from django.template import loader
 from django.views.decorators.cache import never_cache
 
 from waffle import (keyfmt, flag_is_active, sample_is_active,
@@ -11,6 +12,11 @@ from django.conf import settings
 
 @never_cache
 def wafflejs(request):
+    return HttpResponse(_generate_waffle_js(request),
+                       mimetype='application/x-javascript')
+
+
+def _generate_waffle_js(request):
     flags = cache.get(keyfmt(FLAGS_ALL_CACHE_KEY))
     if not flags:
         flags = Flag.objects.values_list('name', flat=True)
@@ -32,7 +38,7 @@ def wafflejs(request):
     switch_default = getattr(settings, 'WAFFLE_SWITCH_DEFAULT', False)
     sample_default = getattr(settings, 'WAFFLE_SAMPLE_DEFAULT', False)
 
-    return render_to_response('waffle/waffle.js',
+    return loader.render_to_string('waffle/waffle.js',
                               {
                                 'flags': flag_values,
                                 'switches': switches,
@@ -40,5 +46,4 @@ def wafflejs(request):
                                 'flag_default': flag_default,
                                 'switch_default': switch_default,
                                 'sample_default': sample_default,
-                              },
-                              mimetype='application/x-javascript')
+                              })


### PR DESCRIPTION
Found this to be a helpful approach to avoid the extra HTTP request for waffle flags in JavaScript.
