### PR TITLE
Updated User model reference based on Django recommendations.

### DIFF
--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -1,6 +1,6 @@
 import django
 
-__all__ = ['User']
+__all__ = ['User', 'get_user_model']
 
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):

--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -4,7 +4,7 @@ __all__ = ['User']
 
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
+    from django.conf import settings
+    User = settings.AUTH_USER_MODEL
 else:
     from django.contrib.auth.models import User

--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -5,12 +5,8 @@ __all__ = ['User', 'get_user_model']
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):
     from django.conf import settings
-    from django.contrib.auth import get_user_model as get_auth_user_model
-
+    from django.contrib.auth import get_user_model
     User = settings.AUTH_USER_MODEL if hasattr(settings, 'AUTH_USER_MODEL') else 'auth.User'
-
-    def get_user_model():
-        return get_auth_user_model()
 
 else:
     from django.contrib.auth.models import User

--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -5,6 +5,15 @@ __all__ = ['User']
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):
     from django.conf import settings
-    User = settings.AUTH_USER_MODEL
+    from django.contrib.auth import get_user_model as get_auth_user_model
+
+    User = settings.AUTH_USER_MODEL if hasattr(settings, 'AUTH_USER_MODEL') else 'auth.User'
+
+    def get_user_model():
+        return get_auth_user_model()
+
 else:
     from django.contrib.auth.models import User
+
+    def get_user_model():
+        return User

--- a/waffle/migrations/0001_initial.py
+++ b/waffle/migrations/0001_initial.py
@@ -3,7 +3,7 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
-from waffle.compat import User
+from waffle.compat import get_user_model
 
 class Migration(SchemaMigration):
 
@@ -34,7 +34,7 @@ class Migration(SchemaMigration):
         db.create_table('waffle_flag_users', (
             ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
             ('flag', models.ForeignKey(orm['waffle.flag'], null=False)),
-            ('user', models.ForeignKey(User, null=False))
+            ('user', models.ForeignKey(get_user_model(), null=False))
         ))
         db.create_unique('waffle_flag_users', ['flag_id', 'user_id'])
 


### PR DESCRIPTION
Changed waffle.compat definition of User object to use
settings.AUTH_USER_MODEL instead of django.contrib.auth.get_user_model().
According to
https://docs.djangoproject.com/en/1.5/topics/auth/customizing/#django.contrib.auth.get_user_model
settings.AUTH_USER_MODEL should be used to define ForeignKey and
ManyToMany relationships instead of the actual User model from
get_user_model().
