### PR TITLE
Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/travis.txt
+++ b/travis.txt
@@ -3,8 +3,7 @@
 nose==1.3.0
 mock==1.0.1
 Jinja2>=2.7.1
-jingo==0.6.1
+jingo==0.7
 South==0.8.3
--e git+git://github.com/jbalogh/test-utils.git@ffccaeda15d7f0477570a6e848bef91f9aa69df9#egg=test-utils
 -e git+git://github.com/jbalogh/django-nose.git@4ffb4fab18957d7c913d7f132dcd27b50a30f447#egg=django-nose
 

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -29,7 +29,7 @@ TEST_COOKIE_NAME = getattr(settings, 'WAFFLE_TESTING_COOKIE', 'dwft_%s')
 def keyfmt(k, v=None):
     if v is None:
         return CACHE_PREFIX + k
-    return CACHE_PREFIX + hashlib.md5(k % v).hexdigest()
+    return CACHE_PREFIX + hashlib.md5((k % v).encode('utf-8')).hexdigest()
 
 
 class DoesNotExist(object):
@@ -108,7 +108,7 @@ def flag_is_active(request, flag_name):
         if group in user_groups:
             return True
 
-    if flag.percent > 0:
+    if flag.percent and flag.percent > 0:
         if not hasattr(request, 'waffles'):
             request.waffles = {}
         elif flag_name in request.waffles:

--- a/waffle/tests/base.py
+++ b/waffle/tests/base.py
@@ -1,10 +1,9 @@
-from django.test import Client
+from django import test
+from django.core import cache
 
-from test_utils import TestCase as BaseTestCase
 
+class TestCase(test.TransactionTestCase):
 
-class TestCase(BaseTestCase):
-    def setUp(self):
-        super(TestCase, self).setUp()
-
-        self.client = Client()
+    def _pre_setup(self):
+        cache.cache.clear()
+        super(TestCase, self)._pre_setup()

--- a/waffle/tests/test_middleware.py
+++ b/waffle/tests/test_middleware.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
+from django.test import RequestFactory
 
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 from waffle.middleware import WaffleMiddleware
 

--- a/waffle/tests/test_templates.py
+++ b/waffle/tests/test_templates.py
@@ -1,9 +1,12 @@
+from django import template
 from django.contrib.auth.models import AnonymousUser
-
-from test_utils import RequestFactory, TestCase
+from django.test import RequestFactory
+from django.test.utils import override_settings
+import mock
 
 from test_app import views
 from waffle.middleware import WaffleMiddleware
+from waffle.tests.base import TestCase
 
 
 def get():
@@ -18,6 +21,7 @@ def process_request(request, view):
 
 
 class WaffleTemplateTests(TestCase):
+
     def test_django_tags(self):
         request = get()
         response = process_request(request, views.flag_in_django)
@@ -36,7 +40,19 @@ class WaffleTemplateTests(TestCase):
         assert 'switch off' in content
         assert 'sample' in content
 
+    @override_settings(TEMPLATE_LOADERS=(
+        'jingo.Loader',
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    ))
+    @mock.patch.object(template.loader, 'template_source_loaders', None)
     def test_jingo_tags(self):
+        """
+            We're manually changing default TEMPLATE_LOADERS to enable jingo
+
+            template_source_loaders needs to be patched to None, otherwise
+            TEMPLATE_LOADERS won't be overriden.
+        """
         request = get()
         response = process_request(request, views.flag_in_jingo)
         self.assertContains(response, 'flag off')

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -3,10 +3,10 @@ import random
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.db import connection
+from django.test import RequestFactory
 
 import mock
 from nose.tools import eq_
-from test_utils import RequestFactory
 
 from test_app import views
 import waffle
@@ -34,7 +34,7 @@ class WaffleTests(TestCase):
         # Flag stays on.
         request.COOKIES['dwf_myflag'] = 'True'
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert 'dwf_myflag' in response.cookies
         eq_('True', response.cookies['dwf_myflag'].value)
 
@@ -45,7 +45,7 @@ class WaffleTests(TestCase):
         # Flag stays off.
         request.COOKIES['dwf_myflag'] = 'False'
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert 'dwf_myflag' in response.cookies
         eq_('False', response.cookies['dwf_myflag'].value)
 
@@ -61,20 +61,20 @@ class WaffleTests(TestCase):
         Flag.objects.create(name='myflag', superusers=True)
         request = get()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         superuser = User(username='foo', is_superuser=True)
         request.user = superuser
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         non_superuser = User(username='bar', is_superuser=False)
         non_superuser.save()
         request.user = non_superuser
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_staff(self):
@@ -82,35 +82,35 @@ class WaffleTests(TestCase):
         Flag.objects.create(name='myflag', staff=True)
         request = get()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         staff = User(username='foo', is_staff=True)
         request.user = staff
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         non_staff = User(username='foo', is_staff=False)
         non_staff.save()
         request.user = non_staff
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_languages(self):
         Flag.objects.create(name='myflag', languages='en,fr')
         request = get()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
 
         request.LANGUAGE_CODE = 'en'
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
 
         request.LANGUAGE_CODE = 'de'
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
 
     def test_user(self):
         """Test the per-user switch."""
@@ -121,12 +121,12 @@ class WaffleTests(TestCase):
         request = get()
         request.user = user
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User.objects.create(username='someone_else')
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_group(self):
@@ -141,13 +141,13 @@ class WaffleTests(TestCase):
         request = get()
         request.user = user
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User(username='someone_else')
         request.user.save()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_authenticated(self):
@@ -156,13 +156,13 @@ class WaffleTests(TestCase):
 
         request = get()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User(username='foo')
         assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_everyone_on(self):
@@ -172,13 +172,13 @@ class WaffleTests(TestCase):
         request = get()
         request.COOKIES['dwf_myflag'] = 'False'
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User(username='foo')
         assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
-        eq_('on', response.content)
+        eq_(b'on', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_everyone_off(self):
@@ -189,13 +189,13 @@ class WaffleTests(TestCase):
         request = get()
         request.COOKIES['dwf_myflag'] = 'True'
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
         request.user = User(username='foo')
         assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
-        eq_('off', response.content)
+        eq_(b'off', response.content)
         assert not 'dwf_myflag' in response.cookies
 
     def test_percent(self):
@@ -266,19 +266,19 @@ class WaffleTests(TestCase):
     def test_set_then_unset_testing_flag(self):
         Flag.objects.create(name='myflag', testing=True)
         response = self.client.get('/flag_in_view?dwft_myflag=1')
-        eq_('on', response.content)
+        eq_(b'on', response.content)
 
         response = self.client.get('/flag_in_view')
-        eq_('on', response.content)
+        eq_(b'on', response.content)
 
         response = self.client.get('/flag_in_view?dwft_myflag=0')
-        eq_('off', response.content)
+        eq_(b'off', response.content)
 
         response = self.client.get('/flag_in_view')
-        eq_('off', response.content)
+        eq_(b'off', response.content)
 
         response = self.client.get('/flag_in_view?dwft_myflag=1')
-        eq_('on', response.content)
+        eq_(b'on', response.content)
 
 
 class SwitchTests(TestCase):


### PR DESCRIPTION
Adding python 3.3 support to waffle.

This PR continues our efforts after #96.
I've rebased necessary changes on top of py3k branch.

I've removed `smart_bytes` on after code review.
