### PR TITLE
Tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,52 @@
+[tox]
+envlist = py2.6-django1.4.X,
+          py2.7-django1.4.X,
+          py2.6-django1.5.X,
+          py2.7-django1.5.X,
+          py2.6-django1.6.X,
+          py2.7-django1.6.X,
+          py3.3-django1.5.X,
+          py3.3-django1.6.X
+
+[testenv]
+commands=./run.sh test
+
+[testenv:py2.6-django1.4.X]
+basepython = python2.6
+deps = Django>=1.4,<1.5
+       -rtravis.txt
+
+[testenv:py2.7-django1.4.X]
+basepython = python2.7
+deps = Django>=1.4,<1.5
+       -rtravis.txt
+
+[testenv:py2.6-django1.5.X]
+basepython = python2.6
+deps = Django>=1.5,<1.6
+       -rtravis.txt
+
+[testenv:py2.7-django1.5.X]
+basepython = python2.7
+deps = Django>=1.5,<1.6
+       -rtravis.txt
+
+[testenv:py2.6-django1.6.X]
+basepython = python2.6
+deps = Django>=1.6,<1.7
+       -rtravis.txt
+
+[testenv:py2.7-django1.6.X]
+basepython = python2.7
+deps = Django>=1.6,<1.7
+       -rtravis.txt
+
+[testenv:py3.3-django1.5.X]
+basepython = python3.3
+deps = Django>=1.5,<1.6
+       -rtravis.txt
+
+[testenv:py3.3-django1.6.X]
+basepython = python3.3
+deps = Django>=1.6,<1.7
+       -rtravis.txt


### PR DESCRIPTION
Tests against Python 2.6-2.7, and 3.3.
Django 1.4-1.6

If it's ok, I can update [travis.yml to use tox too](http://alexgaynor.net/2014/jan/06/why-travis-ci-is-great-for-the-python-community/).

I've been using tox to develop python 2&3 simultaneous support (#96)
