### PR TITLE
Implement abstract base class for flags.

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -45,6 +45,10 @@ class AbstractFlag(models.Model):
     def __unicode__(self):
         return self.name
 
+    def save(self, *args, **kwargs):
+        self.modified = datetime.now()
+        super(AbstractFlag, self).save(*args, **kwargs)
+
     class Meta:
         abstract = True
 
@@ -59,10 +63,6 @@ class Flag(AbstractFlag):
         'Activate this flag for these user groups.'))
     users = models.ManyToManyField(User, blank=True, help_text=(
         'Activate this flag for these users.'))
-
-    def save(self, *args, **kwargs):
-        self.modified = datetime.now()
-        super(Flag, self).save(*args, **kwargs)
 
 
 class Switch(models.Model):

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -9,10 +9,8 @@ from django.db import models
 from waffle.compat import User
 
 
-class Flag(models.Model):
-    """A feature flag.
-
-    Flags are active (or not) on a per-request basis.
+class AbstractFlag(models.Model):
+    """Abstract base class for feature flags.
 
     """
     name = models.CharField(max_length=100, unique=True,
@@ -35,10 +33,6 @@ class Flag(models.Model):
     languages = models.TextField(blank=True, default='', help_text=(
         'Activate this flag for users with one of these languages (comma '
         'separated list)'))
-    groups = models.ManyToManyField(Group, blank=True, help_text=(
-        'Activate this flag for these user groups.'))
-    users = models.ManyToManyField(User, blank=True, help_text=(
-        'Activate this flag for these users.'))
     rollout = models.BooleanField(default=False, help_text=(
         'Activate roll-out mode?'))
     note = models.TextField(blank=True, help_text=(
@@ -50,6 +44,21 @@ class Flag(models.Model):
 
     def __unicode__(self):
         return self.name
+
+    class Meta:
+        abstract = True
+
+
+class Flag(AbstractFlag):
+    """A feature flag.
+
+    Flags are active (or not) on a per-request basis.
+
+    """
+    groups = models.ManyToManyField(Group, blank=True, help_text=(
+        'Activate this flag for these user groups.'))
+    users = models.ManyToManyField(User, blank=True, help_text=(
+        'Activate this flag for these users.'))
 
     def save(self, *args, **kwargs):
         self.modified = datetime.now()


### PR DESCRIPTION
The original implementation was tightly coupled to Django auth user & group models.
The common fields are now abstracted out into the ABC, allowing users to create their own Flag class
with minimal boilerplate.

This is not a matter of a custom user model, per se. In a project, we are using `User` and `Group` from `django.contrib.auth`, but there are is also a second `User` model that exists on a different db we need to reference. It's complicated, but this will eliminate the need for me (and other projects, I assume) to either copy&paste or perform some hackery so my project can play nice with Waffle.
