### PR TITLE
Add flag/switch/sample template filters

### DIFF
--- a/test_app/templates/django/django.html
+++ b/test_app/templates/django/django.html
@@ -40,4 +40,40 @@
   sample_var off
 {% endsample %}
 
+{% if "flag"|flag:request %}
+  flag filter on
+{% else %}
+  flag filter off
+{% endif %}
+
+{% if "switch"|switch %}
+  switch filter on
+{% else %}
+  switch filter off
+{% endif %}
+
+{% if "sample"|sample %}
+  sample filter on
+{% else %}
+  sample filter off
+{% endif %}
+
+{% if flag_var|flag:request %}
+  flag_var filter on
+{% else %}
+  flag_var filter off
+{% endif %}
+
+{% if switch_var|switch %}
+  switch_var filter on
+{% else %}
+  switch_var filter off
+{% endif %}
+
+{% if sample_var|sample %}
+  sample_var filter on
+{% else %}
+  sample_var filter off
+{% endif %}
+
 {% wafflejs %}

--- a/test_app/templates/django/django_email.html
+++ b/test_app/templates/django/django_email.html
@@ -12,3 +12,17 @@
 {% else %}
   sample off
 {% endsample %}
+
+
+{% if "switch"|switch %}
+  switch filter on
+{% else %}
+  switch filter off
+{% endif %}
+
+
+{% if "sample"|sample %}
+  sample filter on
+{% else %}
+  sample filter off
+{% endif %}

--- a/waffle/templatetags/waffle_tags.py
+++ b/waffle/templatetags/waffle_tags.py
@@ -84,3 +84,26 @@ class InlineWaffleJSNode(template.Node):
 @register.tag
 def wafflejs(parser, token):
     return InlineWaffleJSNode()
+
+@register.filter(name="flag")
+def flag_filter(flag_name, request):
+    '''
+    Returns whether the flag is active on the request
+    '''
+    return flag_is_active(request, flag_name)
+
+@register.filter(name="switch")
+def switch_filter(switch_name, request=None):
+    '''
+    Returns whether the switch is active, takes an optional request,
+    which is unused, for consistency with flag_filter
+    '''
+    return switch_is_active(switch_name)
+
+@register.filter(name="sample")
+def sample_filter(sample_name, request=None):
+    '''
+    Returns whether the sample is active, takes an optional request,
+    which is unused, for consistency with flag_filter
+    '''
+    return sample_is_active(sample_name)

--- a/waffle/tests/test_templates.py
+++ b/waffle/tests/test_templates.py
@@ -31,14 +31,22 @@ class WaffleTemplateTests(TestCase):
         self.assertContains(response, 'flag_var off')
         self.assertContains(response, 'switch_var off')
         self.assertContains(response, 'sample_var')
+        self.assertContains(response, 'flag filter off')
+        self.assertContains(response, 'switch filter off')
+        self.assertContains(response, 'sample filter')
+        self.assertContains(response, 'flag_var filter off')
+        self.assertContains(response, 'switch_var filter off')
+        self.assertContains(response, 'sample_var filter')
         self.assertContains(response, 'window.waffle =')
 
     def test_no_request_context(self):
         """Switches and Samples shouldn't require a request context."""
         request = get()
         content = process_request(request, views.no_request_context)
-        assert 'switch off' in content
-        assert 'sample' in content
+        self.assertIn('switch off', content)
+        self.assertIn('sample', content)
+        self.assertIn('switch filter off', content)
+        self.assertIn('sample filter', content)
 
     @override_settings(TEMPLATE_LOADERS=(
         'jingo.Loader',


### PR DESCRIPTION
Small addition, but makes and/or logic in templates straight forward.

Adds filters:
- `flag` 
  - `[flag_name]|flag:request`
- `sample`
  - `[sample_name]|sample` or `[sample_name]|sample:request`
- `switch`
  - `[switch_name]|switch`, or `[switch_name]|switch:request`

Optional request params on `sample` and `switch` are kept to maintain the pattern used in `flag`, but are unused and can be omitted
