### PR TITLE
Using a specific cache from settings

### DIFF
--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -3,11 +3,10 @@ import random
 import hashlib
 
 from django.conf import settings
-from django.core.cache import cache
 from django.db.models.signals import post_save, post_delete, m2m_changed
 
 from waffle.models import Flag, Sample, Switch
-
+from waffle.compat import cache
 
 VERSION = (0, 10)
 __version__ = '.'.join(map(str, VERSION))

--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -1,10 +1,10 @@
 import django
+from django.conf import settings
 
 __all__ = ['User', 'get_user_model']
 
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):
-    from django.conf import settings
     from django.contrib.auth import get_user_model
     User = settings.AUTH_USER_MODEL if hasattr(settings, 'AUTH_USER_MODEL') else 'auth.User'
 
@@ -13,3 +13,14 @@ else:
 
     def get_user_model():
         return User
+
+if hasattr(settings, 'WAFFLE_CACHE_NAME'):
+    cache_name = settings.WAFFLE_CACHE_NAME
+    if django.VERSION >= (1, 7):
+        from django.core.cache import caches
+        cache = caches[cache_name]
+    else:
+        from django.core.cache import get_cache
+        cache = get_cache(cache_name)
+else:
+    from django.core.cache import cache

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -1,4 +1,3 @@
-from django.core.cache import cache
 from django.http import HttpResponse
 from django.template import loader
 from django.views.decorators.cache import never_cache
@@ -7,6 +6,7 @@ from waffle import (keyfmt, flag_is_active, sample_is_active,
                     FLAGS_ALL_CACHE_KEY, SWITCHES_ALL_CACHE_KEY,
                     SAMPLES_ALL_CACHE_KEY)
 from waffle.models import Flag, Sample, Switch
+from waffle.compat import cache
 from django.conf import settings
 
 


### PR DESCRIPTION
Waffle will look for the setting WAFFLE_CACHE_NAME and if it exists,
use that cache instead of the default django cache.

This is done in `compat.py`, as Django 1.7 changes the cache getter API a little.

If you think this is a good approach I can add some docs and maybe some tests, except not quite sure how to test this yet.

resolves #122 
