### PR TITLE
Fix custom user usage

### DIFF
--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -1,18 +1,7 @@
 import django
 from django.conf import settings
 
-__all__ = ['User', 'get_user_model']
-
-# Django 1.5+ compatibility
-if django.VERSION >= (1, 5):
-    from django.contrib.auth import get_user_model
-    User = settings.AUTH_USER_MODEL if hasattr(settings, 'AUTH_USER_MODEL') else 'auth.User'
-
-else:
-    from django.contrib.auth.models import User
-
-    def get_user_model():
-        return User
+__all__ = ['cache']
 
 if hasattr(settings, 'WAFFLE_CACHE_NAME'):
     cache_name = settings.WAFFLE_CACHE_NAME
@@ -24,3 +13,5 @@ if hasattr(settings, 'WAFFLE_CACHE_NAME'):
         cache = get_cache(cache_name)
 else:
     from django.core.cache import cache
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')

--- a/waffle/migrations/0001_initial.py
+++ b/waffle/migrations/0001_initial.py
@@ -1,9 +1,21 @@
 # encoding: utf-8
 import datetime
+import django
+
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
-from waffle.compat import get_user_model
+
+
+# Django 1.5+ compatibility
+if django.VERSION >= (1, 5):
+    from django.contrib.auth import get_user_model
+else:
+    from django.contrib.auth.models import User
+
+    def get_user_model():
+        return User
+
 
 class Migration(SchemaMigration):
 

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -6,7 +6,7 @@ except ImportError:
 from django.contrib.auth.models import Group
 from django.db import models
 
-from waffle.compat import User
+from waffle.compat import AUTH_USER_MODEL
 
 
 class Flag(models.Model):
@@ -37,7 +37,7 @@ class Flag(models.Model):
         'separated list)'))
     groups = models.ManyToManyField(Group, blank=True, help_text=(
         'Activate this flag for these user groups.'))
-    users = models.ManyToManyField(User, blank=True, help_text=(
+    users = models.ManyToManyField(AUTH_USER_MODEL, blank=True, help_text=(
         'Activate this flag for these users.'))
     rollout = models.BooleanField(default=False, help_text=(
         'Activate roll-out mode?'))


### PR DESCRIPTION
This PR fixes circular imports by using only the constant `AUTH_USER_MODEL` in `waffle/models.py`.

The south initial migration still use `get_user_model`.
