### PR TITLE
Export signals methods to models.py

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -5,8 +5,10 @@ except ImportError:
 
 from django.contrib.auth.models import Group
 from django.db import models
+from django.db.models.signals import post_save, post_delete, m2m_changed
 
-from waffle.compat import AUTH_USER_MODEL
+from .compat import AUTH_USER_MODEL, cache
+from . import keyfmt, settings
 
 
 class Flag(models.Model):
@@ -106,3 +108,61 @@ class Sample(models.Model):
     def save(self, *args, **kwargs):
         self.modified = datetime.now()
         super(Sample, self).save(*args, **kwargs)
+
+
+def cache_flag(**kwargs):
+    action = kwargs.get('action', None)
+    # action is included for m2m_changed signal. Only cache on the post_*.
+    if not action or action in ['post_add', 'post_remove', 'post_clear']:
+        f = kwargs.get('instance')
+        cache.add(keyfmt(settings.FLAG_CACHE_KEY, f.name), f)
+        cache.add(keyfmt(settings.FLAG_USERS_CACHE_KEY, f.name), f.users.all())
+        cache.add(keyfmt(settings.FLAG_GROUPS_CACHE_KEY, f.name), f.groups.all())
+
+
+def uncache_flag(**kwargs):
+    flag = kwargs.get('instance')
+    data = {
+        keyfmt(settings.FLAG_CACHE_KEY, flag.name): None,
+        keyfmt(settings.FLAG_USERS_CACHE_KEY, flag.name): None,
+        keyfmt(settings.FLAG_GROUPS_CACHE_KEY, flag.name): None,
+        keyfmt(settings.FLAGS_ALL_CACHE_KEY): None
+    }
+    cache.set_many(data, 5)
+
+post_save.connect(uncache_flag, sender=Flag, dispatch_uid='save_flag')
+post_delete.connect(uncache_flag, sender=Flag, dispatch_uid='delete_flag')
+m2m_changed.connect(uncache_flag, sender=Flag.users.through,
+                    dispatch_uid='m2m_flag_users')
+m2m_changed.connect(uncache_flag, sender=Flag.groups.through,
+                    dispatch_uid='m2m_flag_groups')
+
+
+def cache_sample(**kwargs):
+    sample = kwargs.get('instance')
+    cache.add(keyfmt(settings.SAMPLE_CACHE_KEY, sample.name), sample)
+
+
+def uncache_sample(**kwargs):
+    sample = kwargs.get('instance')
+    cache.set(keyfmt(settings.SAMPLE_CACHE_KEY, sample.name), None, 5)
+    cache.set(keyfmt(settings.SAMPLES_ALL_CACHE_KEY), None, 5)
+
+post_save.connect(uncache_sample, sender=Sample, dispatch_uid='save_sample')
+post_delete.connect(uncache_sample, sender=Sample,
+                    dispatch_uid='delete_sample')
+
+
+def cache_switch(**kwargs):
+    switch = kwargs.get('instance')
+    cache.add(keyfmt(settings.SWITCH_CACHE_KEY, switch.name), switch)
+
+
+def uncache_switch(**kwargs):
+    switch = kwargs.get('instance')
+    cache.set(keyfmt(settings.SWITCH_CACHE_KEY, switch.name), None, 5)
+    cache.set(keyfmt(settings.SWITCHES_ALL_CACHE_KEY), None, 5)
+
+post_delete.connect(uncache_switch, sender=Switch,
+                    dispatch_uid='delete_switch')
+post_save.connect(uncache_switch, sender=Switch, dispatch_uid='save_switch')


### PR DESCRIPTION
This PR moves all signals models from `__init__.py` to `models.py`
and add all models imports in each methods to avoid Django loading errors.
