### PR TITLE
Expose ability to all flags, switches, samples

### DIFF
--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -154,7 +154,7 @@ def all_flags(request):
     if flags is None:
         flags = Flag.objects.values_list('name', flat=True)
         cache.add(keyfmt(settings.FLAGS_ALL_CACHE_KEY), flags)
-    flag_values = [(f, flag_is_active(request, f)) for f in flags]
+    flag_values = dict((f, flag_is_active(request, f)) for f in flags)
 
     return flag_values
 

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -144,3 +144,41 @@ def sample_is_active(sample_name):
             return settings.SAMPLE_DEFAULT
 
     return Decimal(str(random.uniform(0, 100))) <= sample.percent
+
+
+def all_flags(request):
+    from .compat import cache
+    from .models import Flag
+
+    flags = cache.get(keyfmt(settings.FLAGS_ALL_CACHE_KEY))
+    if flags is None:
+        flags = Flag.objects.values_list('name', flat=True)
+        cache.add(keyfmt(settings.FLAGS_ALL_CACHE_KEY), flags)
+    flag_values = [(f, flag_is_active(request, f)) for f in flags]
+
+    return flag_values
+
+
+def all_switches():
+    from .models import Switch
+    from .compat import cache
+
+    switches = cache.get(keyfmt(settings.SWITCHES_ALL_CACHE_KEY))
+    if switches is None:
+        switches = Switch.objects.values_list('name', 'active')
+        cache.add(keyfmt(settings.SWITCHES_ALL_CACHE_KEY), switches)
+
+    return switches
+
+
+def all_samples():
+    from .compat import cache
+    from .models import Sample
+
+    samples = cache.get(keyfmt(settings.SAMPLES_ALL_CACHE_KEY))
+    if samples is None:
+        samples = Sample.objects.values_list('name', flat=True)
+        cache.add(keyfmt(settings.SAMPLES_ALL_CACHE_KEY), samples)
+    sample_values = [(s, sample_is_active(s)) for s in samples]
+
+    return sample_values

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -238,13 +238,13 @@ class WaffleTests(TestCase):
         Flag.objects.create(name='myflag1', everyone=True)
         request = get()
         flags = waffle.all_flags(request)
-        assert ('myflag1', True) in flags
+        assert flags['myflag1'] == True
 
         Flag.objects.create(name='myflag2', everyone=True)
 
         request = get()
         flags = waffle.all_flags(request)
-        assert ('myflag2', True) in flags
+        assert flags['myflag2'] == True
 
     def test_all_switches(self):
         """Test the 'SWITCHES_ALL' list gets invalidated correctly."""

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -233,6 +233,41 @@ class WaffleTests(TestCase):
         request = get()
         assert waffle.flag_is_active(request, 'foo')
 
+    def test_all_flags(self):
+        """Test the 'FLAGS_ALL' list gets invalidated correctly."""
+        Flag.objects.create(name='myflag1', everyone=True)
+        request = get()
+        flags = waffle.all_flags(request)
+        assert ('myflag1', True) in flags
+
+        Flag.objects.create(name='myflag2', everyone=True)
+
+        request = get()
+        flags = waffle.all_flags(request)
+        assert ('myflag2', True) in flags
+
+    def test_all_switches(self):
+        """Test the 'SWITCHES_ALL' list gets invalidated correctly."""
+        switch = Switch.objects.create(name='myswitch', active=True)
+        switches = waffle.all_switches()
+        assert ('myswitch', True) in switches
+
+        switch.active = False
+        switch.save()
+        switches = waffle.all_switches()
+        assert ('myswitch', False) in switches
+
+    def test_all_samples(self):
+        """Test the 'SAMPLES_ALL' list gets invalidated correctly."""
+        Sample.objects.create(name='sample1', percent='100.0')
+        samples = waffle.all_samples()
+        assert ('sample1', True) in samples
+
+        Sample.objects.create(name='sample2', percent='100.0')
+
+        samples = waffle.all_samples()
+        assert ('sample2', True) in samples
+
     @mock.patch.object(settings, 'OVERRIDE', True)
     def test_override(self):
         request = get(foo='1')

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -15,7 +15,7 @@ def wafflejs(request):
 
 
 def _generate_waffle_js(request):
-    flag_values = all_flags(request)
+    flag_values = list(all_flags(request).items())
     switches = all_switches()
     sample_values = all_samples()
 

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -2,7 +2,8 @@ from django.http import HttpResponse
 from django.template import loader
 from django.views.decorators.cache import never_cache
 
-from . import (keyfmt, flag_is_active, sample_is_active, settings)
+from . import (keyfmt, flag_is_active, sample_is_active, settings,
+               all_flags, all_switches, all_samples)
 from .models import Flag, Sample, Switch
 from .compat import cache
 
@@ -14,22 +15,9 @@ def wafflejs(request):
 
 
 def _generate_waffle_js(request):
-    flags = cache.get(keyfmt(settings.FLAGS_ALL_CACHE_KEY))
-    if flags is None:
-        flags = Flag.objects.values_list('name', flat=True)
-        cache.add(keyfmt(settings.FLAGS_ALL_CACHE_KEY), flags)
-    flag_values = [(f, flag_is_active(request, f)) for f in flags]
-
-    switches = cache.get(keyfmt(settings.SWITCHES_ALL_CACHE_KEY))
-    if switches is None:
-        switches = Switch.objects.values_list('name', 'active')
-        cache.add(keyfmt(settings.SWITCHES_ALL_CACHE_KEY), switches)
-
-    samples = cache.get(keyfmt(settings.SAMPLES_ALL_CACHE_KEY))
-    if samples is None:
-        samples = Sample.objects.values_list('name', flat=True)
-        cache.add(keyfmt(settings.SAMPLES_ALL_CACHE_KEY), samples)
-    sample_values = [(s, sample_is_active(s)) for s in samples]
+    flag_values = all_flags(request)
+    switches = all_switches()
+    sample_values = all_samples()
 
     flag_default = getattr(settings, 'WAFFLE_FLAG_DEFAULT', False)
     switch_default = getattr(settings, 'WAFFLE_SWITCH_DEFAULT', False)


### PR DESCRIPTION
Add new waffle functions all_flags(), all_switches(), and add_samples().  Move
the code from views.py, add top-level tests.

Basically moves the initial code from `_generate_waffle_js()` to separated functions in `waffle.__init__.py` allowing that ability externally.
