### PR TITLE
Support bulk flag checks

### DIFF
--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -59,9 +59,9 @@ def flag_is_active(request, flag_name):
 
 
 def _full_flag_is_active(request, flag):
-    from .compat import cache
+    from .compat import cache, is_string
 
-    if isinstance(flag, basestring):
+    if is_string(flag):
         return settings.FLAG_DEFAULT
 
     if settings.OVERRIDE:

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -115,6 +115,10 @@ def flag_is_active(request, flag_name):
     return False
 
 
+def flags_are_active(flags, request):
+    return [(f, flag_is_active(request, f)) for f in flags]
+
+
 def switch_is_active(switch_name):
     from .models import cache_switch, Switch
     from .compat import cache

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -40,7 +40,7 @@ def get_flags(flag_names):
     cached_flag_names = set([f.name for f in cached_flags])
 
     missing_flag_names = set(flag_names).difference(cached_flag_names)
-    uncached_flags = Flag.objects.filter(name__in=missing_flag_names)
+    uncached_flags = Flag.objects.filter(name__in=missing_flag_names).prefetch_related('users', 'groups')
     cache_flags(instances=uncached_flags)
     uncached_flag_names = set([f.name for f in uncached_flags])
 

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -42,13 +42,14 @@ def get_flags(flag_names):
     cache_flags(instances=uncached_flags)
     uncached_flag_names = set([f.name for f in uncached_flags])
     missing_flag_names = missing_flag_names.difference(uncached_flag_names)
+    missing_flags = [Flag(name=f_name, everyone=settings.FLAG_DEFAULT) for f_name in missing_flag_names]
 
-    return list(cached_flags) + list(uncached_flags) + list(missing_flag_names)
+    return list(cached_flags) + list(uncached_flags), missing_flags
 
 
 def flags_are_active(request, flag_names):
-    full_flags = get_flags(flag_names)
-    flags = [(f, _full_flag_is_active(request, f)) for f in full_flags]
+    full_flags, missing_flags = get_flags(flag_names)
+    flags = [(f, _full_flag_is_active(request, f)) for f in full_flags + missing_flags]
     return flags
 
 
@@ -59,10 +60,7 @@ def flag_is_active(request, flag_name):
 
 
 def _full_flag_is_active(request, flag):
-    from .compat import cache, is_string
-
-    if is_string(flag):
-        return settings.FLAG_DEFAULT
+    from .compat import cache
 
     if settings.OVERRIDE:
         if flag.name in request.GET:

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -38,10 +38,12 @@ def get_flags(flag_names):
     flag_keys = [keyfmt(settings.FLAG_CACHE_KEY, f) for f in flag_names]
     cached_flags = cache.get_many(flag_keys).values()
     cached_flag_names = set([f.name for f in cached_flags])
+
     missing_flag_names = set(flag_names).difference(cached_flag_names)
     uncached_flags = Flag.objects.filter(name__in=missing_flag_names)
     cache_flags(instances=uncached_flags)
     uncached_flag_names = set([f.name for f in uncached_flags])
+
     missing_flag_names = missing_flag_names.difference(uncached_flag_names)
     missing_flags = [Flag(name=f_name, everyone=settings.FLAG_DEFAULT) for f_name in missing_flag_names]
 

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -48,7 +48,7 @@ def get_flags(flag_names):
 
 def flags_are_active(request, flag_names):
     full_flags = get_flags(flag_names)
-    flags = [(f, full_flag_is_active(request, f)) for f in full_flags]
+    flags = [(f, _full_flag_is_active(request, f)) for f in full_flags]
     return flags
 
 
@@ -58,9 +58,8 @@ def flag_is_active(request, flag_name):
     return flags[0][1]
 
 
-def full_flag_is_active(request, flag):
+def _full_flag_is_active(request, flag):
     from .compat import cache
-    from .models import cache_flag
 
     if isinstance(flag, basestring):
         return settings.FLAG_DEFAULT
@@ -103,16 +102,10 @@ def full_flag_is_active(request, flag):
             return True
 
     flag_users = cache.get(keyfmt(settings.FLAG_USERS_CACHE_KEY, flag.name))
-    if flag_users is None:
-        flag_users = flag.users.all()
-        cache_flag(instance=flag)
     if user in flag_users:
         return True
 
     flag_groups = cache.get(keyfmt(settings.FLAG_GROUPS_CACHE_KEY, flag.name))
-    if flag_groups is None:
-        flag_groups = flag.groups.all()
-        cache_flag(instance=flag)
     user_groups = user.groups.all()
     for group in flag_groups:
         if group in user_groups:

--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -15,18 +15,3 @@ else:
     from django.core.cache import cache
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
-
-
-def is_string(obj):
-    try:
-        # Python 2
-        if isinstance(obj, basestring):
-            return True
-        else:
-            return False
-    except NameError:
-        # Python 3
-        if isinstance(obj, str):
-            return True
-        else:
-            return False

--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -15,3 +15,18 @@ else:
     from django.core.cache import cache
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
+
+def is_string(obj):
+    try:
+        # Python 2
+        if isinstance(obj, basestring):
+            return True
+        else:
+            return False
+    except NameError:
+        # Python 3
+        if isinstance(obj, str):
+            return True
+        else:
+            return False

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -120,6 +120,18 @@ def cache_flag(**kwargs):
         cache.add(keyfmt(settings.FLAG_GROUPS_CACHE_KEY, f.name), f.groups.all())
 
 
+def cache_flags(**kwargs):
+    cache_dict = {}
+    flags = kwargs.get('instances')
+
+    for f in flags:
+        cache_dict[keyfmt(settings.FLAG_CACHE_KEY, f.name)] = f
+        cache_dict[keyfmt(settings.FLAG_USERS_CACHE_KEY, f.name)] = f.users.all()
+        cache_dict[keyfmt(settings.FLAG_GROUPS_CACHE_KEY, f.name)] = f.groups.all()
+
+    cache.set_many(cache_dict)
+
+
 def uncache_flag(**kwargs):
     flag = kwargs.get('instance')
     data = {

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.core import cache
 from django.core.urlresolvers import reverse
 
 from waffle.models import Flag, Sample, Switch
@@ -49,3 +50,18 @@ class WaffleViewTests(TestCase):
         response = self.client.get(reverse('wafflejs'))
         self.assertEqual(200, response.status_code)
         assert ('sample2', True) in response.context['samples']
+
+    def test_queries(self):
+        Flag.objects.create(name='1', everyone=True)
+
+        with self.assertNumQueries(6):
+            response = self.client.get(reverse('wafflejs'))
+            self.assertEqual(200, response.status_code)
+
+        cache.cache.clear()
+
+        Flag.objects.create(name='2', everyone=True)
+
+        with self.assertNumQueries(6):
+            response = self.client.get(reverse('wafflejs'))
+            self.assertEqual(200, response.status_code)

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -51,7 +51,7 @@ class WaffleViewTests(TestCase):
         self.assertEqual(200, response.status_code)
         assert ('sample2', True) in response.context['samples']
 
-    def test_queries(self):
+    def test_db_queries_constant(self):
         Flag.objects.create(name='1', everyone=True)
 
         with self.assertNumQueries(6):

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -36,7 +36,7 @@ def _generate_waffle_js(request):
     sample_default = getattr(settings, 'WAFFLE_SAMPLE_DEFAULT', False)
 
     return loader.render_to_string('waffle/waffle.js', {
-        'flags': flag_values,
+        'flags': [(f[0].name, f[1]) for f in flag_values],
         'switches': switches,
         'samples': sample_values,
         'flag_default': flag_default,

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -18,7 +18,7 @@ def _generate_waffle_js(request):
     if flags is None:
         flags = Flag.objects.values_list('name', flat=True)
         cache.add(keyfmt(settings.FLAGS_ALL_CACHE_KEY), flags)
-    flag_values = flags_are_active(flags, request)
+    flag_values = flags_are_active(request, flags)
 
     switches = cache.get(keyfmt(settings.SWITCHES_ALL_CACHE_KEY))
     if switches is None:

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -2,7 +2,7 @@ from django.http import HttpResponse
 from django.template import loader
 from django.views.decorators.cache import never_cache
 
-from . import (keyfmt, flag_is_active, sample_is_active, settings)
+from . import (keyfmt, flags_are_active, sample_is_active, settings)
 from .models import Flag, Sample, Switch
 from .compat import cache
 
@@ -18,7 +18,7 @@ def _generate_waffle_js(request):
     if flags is None:
         flags = Flag.objects.values_list('name', flat=True)
         cache.add(keyfmt(settings.FLAGS_ALL_CACHE_KEY), flags)
-    flag_values = [(f, flag_is_active(request, f)) for f in flags]
+    flag_values = flags_are_active(flags, request)
 
     switches = cache.get(keyfmt(settings.SWITCHES_ALL_CACHE_KEY))
     if switches is None:


### PR DESCRIPTION
This is an attempt at fixing the number of queries when checking many flags (see #77 for wafflejs template tags).
### Notes
- I attempted to do this without affecting waffle's API - as you can see, existing tests have not needed to be updated
  - In order to do this, `flag_is_active` has been changed to a wrapper which calls the new `flags_are_active` function with a list consisting of one flag name
  - This allowed me to extract any logic dealing with bulk queries (either DB or cache) out into the `flags_are_active` / `get_flags` functions
- Tests
  - I've only added the one test for the db query check so far
  - I haven't figured out how to test that the number of cache queries is constant yet (likely need to do something with mock)
  - I'm not sure how much coverage the existing tests have, but they're all passing right now
- The naming of some of the functions / variables can probably be improved, this was more of a proof-of-concept
