### PR TITLE
use django.utils.translation for flag languages

### DIFF
--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 import random
 
+from django.utils import translation
+
 from waffle.utils import get_setting, keyfmt
 
 
@@ -67,8 +69,7 @@ def flag_is_active(request, flag_name):
 
     if flag.languages:
         languages = flag.languages.split(',')
-        if (hasattr(request, 'LANGUAGE_CODE') and
-                request.LANGUAGE_CODE in languages):
+        if translation.get_language() in languages:
             return True
 
     flag_users = cache.get(keyfmt(get_setting('FLAG_USERS_CACHE_KEY'),

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import AnonymousUser, Group, User
 from django.db import connection
 from django.test import RequestFactory
 from django.test.utils import override_settings
+from django.utils import translation
 
 import mock
 
@@ -103,11 +104,11 @@ class WaffleTests(TestCase):
         response = process_request(request, views.flag_in_view)
         self.assertEqual(b'off', response.content)
 
-        request.LANGUAGE_CODE = 'en'
+        translation.activate('en')
         response = process_request(request, views.flag_in_view)
         self.assertEqual(b'on', response.content)
 
-        request.LANGUAGE_CODE = 'de'
+        translation.activate('de')
         response = process_request(request, views.flag_in_view)
         self.assertEqual(b'off', response.content)
 


### PR DESCRIPTION
Flags use `request.LANGUAGE_CODE` to check for languages. That requires `django.middleware.locale.LocaleMiddleware`, which isn't explained in the docs.

This PR changes flag languages logic to use `django.utils.translation` above the `LocaleMiddleware` so that projects using other locale middlewares can still use waffle Flag languages feature.

If this is a WONTFIX, I'll send another PR that adds the `django.middlware.locale.LocaleMiddlware` requirement to the docs and the admin site interface.
