### PR TITLE
Added support for using override_* decorators on test classes

### DIFF
--- a/waffle/compat.py
+++ b/waffle/compat.py
@@ -1,7 +1,10 @@
 import django
+import sys
+import types
 from django.conf import settings
 
 __all__ = ['cache']
+PY3 = sys.version_info[0] == 3
 
 if hasattr(settings, 'WAFFLE_CACHE_NAME'):
     cache_name = settings.WAFFLE_CACHE_NAME
@@ -15,3 +18,7 @@ else:
     from django.core.cache import cache
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
+CLASS_TYPES = (type,)
+if not PY3:
+    CLASS_TYPES = (type, types.ClassType)

--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -185,3 +185,33 @@ class OverrideSampleTests(TestCase):
             assert not waffle.sample_is_active('foo')
 
         assert not Sample.objects.filter(name='foo').exists()
+
+
+@override_switch('foo', active=False)
+class OverrideSwitchOnClassTests(TestCase):
+    def setUp(self):
+        assert not Switch.objects.filter(name='foo').exists()
+        Switch.objects.create(name='foo', active=True)
+
+    def test_undecorated_method_is_set_properly_for_switch(self):
+        self.assertFalse(waffle.switch_is_active('foo'))
+
+
+@override_flag('foo', active=False)
+class OverrideFlagOnClassTests(TestCase):
+    def setUp(self):
+        assert not Flag.objects.filter(name='foo').exists()
+        Flag.objects.create(name='foo', everyone=True)
+
+    def test_undecorated_method_is_set_properly_for_flag(self):
+        self.assertFalse(waffle.flag_is_active(req(), 'foo'))
+
+
+@override_sample('foo', active=False)
+class OverrideSampleOnClassTests(TestCase):
+    def setUp(self):
+        assert not Sample.objects.filter(name='foo').exists()
+        Sample.objects.create(name='foo', percent='100.0')
+
+    def test_undecorated_method_is_set_properly_for_sample(self):
+        self.assertFalse(waffle.sample_is_active('foo'))

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+from waffle.compat import CLASS_TYPES
 from waffle.models import Flag, Switch, Sample
 
 
@@ -12,10 +13,35 @@ class _overrider(object):
         self.active = active
 
     def __call__(self, func):
+        if isinstance(func, CLASS_TYPES):
+            return self.for_class(func)
+        else:
+            return self.for_callable(func)
+
+    def for_class(self, obj):
+        """Wraps a class's test methods in the decorator"""
+        for attr in dir(obj):
+            if not attr.startswith('test_'):
+                # Ignore non-test functions
+                continue
+
+            attr_value = getattr(obj, attr)
+
+            if not callable(attr_value):
+                # Ignore non-functions
+                continue
+
+            setattr(obj, attr, self.for_callable(attr_value))
+
+        return obj
+
+    def for_callable(self, func):
+        """Wraps a method in the decorator"""
         @wraps(func)
         def _wrapped(*args, **kwargs):
             with self:
                 return func(*args, **kwargs)
+
         return _wrapped
 
     def get(self):


### PR DESCRIPTION
Currently, `override_flag`, `override_switch`, and `override_sample` only work as decorators on methods.

This PR makes it so:

``` python
@override_flag('my-flag', active=True)
class MyTestCase(unittest.TestCase)
   def first_test(self):
       ...
   def second_test(self):
       ...
```

is equivalent to:

``` python
class MyTestCase(unittest.TestCase)
   @override_flag('my-flag', active=True)
   def first_test(self):
       ...
   @override_flag('my-flag', active=True)
   def second_test(self):
       ...
```
