### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/starting/configuring.rst
+++ b/docs/starting/configuring.rst
@@ -9,7 +9,7 @@ behavior.
 
 ``WAFFLE_COOKIE``
     The format for the cookies Waffle sets. Must contain ``%s``.
-    Defaults to ``dwf_%s``.
+    Defaults to ``dwft_%s``.
 
 ``WAFFLE_FLAG_DEFAULT``
     When a Flag is undefined in the database, Waffle considers it

--- a/docs/testing/user.rst
+++ b/docs/testing/user.rst
@@ -27,7 +27,7 @@ parameter (like ``WAFFLE_OVERRIDE``) but is unique for two reasons:
   cookies.
 
 If the flag we're testing is called ``foo``, then we can enable testing
-mode, and send users to ``oursite.com/testpage?dwtf_foo=1`` (or ``=0``)
+mode, and send users to ``oursite.com/testpage?dwft_foo=1`` (or ``=0``)
 and the flag will be on (or off) for them for the remainder of their
 session.
 


### PR DESCRIPTION
From: https://github.com/jsocol/django-waffle/blob/master/waffle/defaults.py#L5
`TEST_COOKIE = 'dwft_%s'`
