### PR TITLE
Add initial attempt at env-var based flag specification (and tests).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # These are required to run the tests.
 Django
+django_jinja
 flake8
 
 # Everything else is in a Django-version-free version


### PR DESCRIPTION
This PR introduces a new capability. **It is unfinished** (only flagging is supported) and this PR is where discussion of ongoing development can be had with upstream project owner. This work is being done with @rossbruniges.

**What?**

I'm working for a client whose Django website is "stateless" (i.e. does not have a database backend). This branch makes it easy to use three arbitrary "buckets" for specifying flags defined in environment variables: ALPHA, BETA and ALL, thus making it possible to use Waffle with websites that are not backed by a database.

**Why?**

My client wants to use feature flags and Waffle is awesome. Furthermore, not all websites are "typical" in that they use a database for storing state.

**How?**

There are three arbitrary buckets: ALPHA, BETA and ALL. ALPHA and BETA have named users associated with them and flags set for each bucket will only be active for those users. ALL related flags apply to all users. The choice of arbitrary bucket names was made to reflect the common pattern of rolling out a feature first in "alpha", then "beta" and then to "all" users. It is assumed that once a feature has been around long enough and there's no requirement for it to be on/off at short notice, then the flag related code should be removed from this feature.

We use the following environment variables for specifying flag/user state:
- `WAFFLE_USE_ENV_VARS` - a simple truthy flag to indicate that waffle should use the env vars instead of the database when checking if a `flag_is_active`.
- `WAFFLE_ALPHA_USERS` - a comma separated list of usernames for those in the ALPHA bucket (the stateless Django app will need to implement a faux-`request.user.username` to identify the individual users).
- `WAFFLE_BETA_USERS` - as with WAFFLE_ALPHA_USERS but for BETA users.
- `WAFFLE_ALPHA_FLAGS` - a comma separated list of flags in the ALPHA bucket.
- `WAFFLE_BETA_FLAGS` - a comma separated list of flags in the BETA bucket.
- `WAFFLE_ALL_FLAGS` - a comma separated list of flags in the ALL bucket.
- `WAFFLE_SWITCHES` - TBD.
- `WAFFLE_SAMPLES` - TBD.

This is most definitely a first draft of this functionality. I'm not precious about my code: comments, constructive critique and ideas are most welcome. "Not interested" is also a valid response! :-)

In any case, my client needs this feature so I'll be working on it over the coming weeks and, if useful, would like to make the work available upstream.
