### PR TITLE
Easier Django upgrades by caching a plain list instead of `ValuesListQuerySet`

### DIFF
--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -11,7 +11,9 @@ class WaffleViewTests(TestCase):
         response = self.client.get(reverse('wafflejs'))
         self.assertEqual(200, response.status_code)
         self.assertEqual('application/x-javascript', response['content-type'])
-        self.assertEqual('max-age=0', response['cache-control'])
+        cache_control = [control.strip()
+                         for control in response['cache-control'].split(',')]
+        self.assertIn('max-age=0', cache_control)
 
     def test_flush_all_flags(self):
         """Test the 'FLAGS_ALL' list gets invalidated correctly."""

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -19,18 +19,18 @@ def wafflejs(request):
 def _generate_waffle_js(request):
     flags = cache.get(keyfmt(get_setting('ALL_FLAGS_CACHE_KEY')))
     if flags is None:
-        flags = Flag.objects.values_list('name', flat=True)
+        flags = list(Flag.objects.values_list('name', flat=True))
         cache.add(keyfmt(get_setting('ALL_FLAGS_CACHE_KEY')), flags)
     flag_values = [(f, flag_is_active(request, f)) for f in flags]
 
     switches = cache.get(keyfmt(get_setting('ALL_SWITCHES_CACHE_KEY')))
     if switches is None:
-        switches = Switch.objects.values_list('name', 'active')
+        switches = list(Switch.objects.values_list('name', 'active'))
         cache.add(keyfmt(get_setting('ALL_SWITCHES_CACHE_KEY')), switches)
 
     samples = cache.get(keyfmt(get_setting('ALL_SAMPLES_CACHE_KEY')))
     if samples is None:
-        samples = Sample.objects.values_list('name', flat=True)
+        samples = list(Sample.objects.values_list('name', flat=True))
         cache.add(keyfmt(get_setting('ALL_SAMPLES_CACHE_KEY')), samples)
     sample_values = [(s, sample_is_active(s)) for s in samples]
 


### PR DESCRIPTION
`waffle.views._generate_waffle_js` was storing the result of `values_list` in a cache key. Although it looks like a list, it's actually an instance of `ValuesListQuerySet`. I encountered a bug in an application that was using a cache backend that pickled complex Python objects: upgrading major Django versions meant the values currently in the cache wouldn't deserialize correctly, throwing an error in the wafflejs view. Using vanilla lists of strings (which is really the intended effect here) makes it slightly more resistant to these upgrades.

I also fixed a brittle test case that broke on Django 1.9 (the `@never_cache` decorator now returns a few more directives).
