### PR TITLE
Remove patterns as it is deprecated

### DIFF
--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.contrib import admin
 from django.http import HttpResponseNotFound, HttpResponseServerError
 
@@ -10,7 +10,7 @@ handler500 = lambda r: HttpResponseServerError()
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^flag_in_view', views.flag_in_view, name='flag_in_view'),
     url(r'^switch-on', views.switched_view),
     url(r'^switch-off', views.switched_off_view),
@@ -25,4 +25,4 @@ urlpatterns = patterns('',
     url(r'^flag-off', views.flagged_off_view),
     (r'^', include('waffle.urls')),
     (r'^admin/', include(admin.site.urls))
-)
+]

--- a/waffle/urls.py
+++ b/waffle/urls.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from waffle.views import wafflejs
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^wafflejs$', wafflejs, name='wafflejs'),
-)
+]


### PR DESCRIPTION
The `patterns` function is deprecated and will be removed in Django 1.10. Updating this removes a warning.
