### PR TITLE
Overhaul caching.

### DIFF
--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -21,8 +21,15 @@ def disable_for_all(ma, request, qs):
 disable_for_all.short_description = 'Disable selected flags for everyone.'
 
 
+def delete_flags(ma, request, qs):
+    # Iterate over all objects to cause cache invalidation.
+    for f in qs.all():
+        f.delete()
+delete_flags.short_description = 'Delete the selected flags.'
+
+
 class FlagAdmin(admin.ModelAdmin):
-    actions = [enable_for_all, disable_for_all]
+    actions = [enable_for_all, disable_for_all, delete_flags]
     date_hierarchy = 'created'
     list_display = ('name', 'note', 'everyone', 'percent', 'superusers',
                     'staff', 'authenticated', 'languages')

--- a/waffle/managers.py
+++ b/waffle/managers.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.db import models
+
+from waffle.utils import get_setting, get_cache
+
+
+cache = get_cache()
+
+
+class BaseManager(models.Manager):
+    KEY_SETTING = ''
+
+    def create(self, *args, **kwargs):
+        ret = super(BaseManager, self).create(*args, **kwargs)
+        cache_key = get_setting(self.KEY_SETTING)
+        cache.delete(cache_key)
+        return ret
+
+
+class FlagManager(BaseManager):
+    KEY_SETTING = 'ALL_FLAGS_CACHE_KEY'
+
+
+class SwitchManager(BaseManager):
+    KEY_SETTING = 'ALL_SWITCHES_CACHE_KEY'
+
+
+class SampleManager(BaseManager):
+    KEY_SETTING = 'ALL_SAMPLES_CACHE_KEY'

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -23,7 +23,6 @@ class WaffleViewTests(TestCase):
         assert ('myflag1', True) in response.context['flags']
 
         Flag.objects.create(name='myflag2', everyone=True)
-
         response = self.client.get(reverse('wafflejs'))
         self.assertEqual(200, response.status_code)
         assert ('myflag2', True) in response.context['flags']

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -99,7 +99,9 @@ class override_switch(_overrider):
     cls = Switch
 
     def update(self, active):
-        self.cls.objects.filter(pk=self.obj.pk).update(active=active)
+        obj = self.cls.objects.get(pk=self.obj.pk)
+        obj.active = active
+        obj.save()
 
     def get_value(self):
         return self.obj.active
@@ -109,7 +111,9 @@ class override_flag(_overrider):
     cls = Flag
 
     def update(self, active):
-        self.cls.objects.filter(pk=self.obj.pk).update(everyone=active)
+        obj = self.cls.objects.get(pk=self.obj.pk)
+        obj.everyone = active
+        obj.save()
 
     def get_value(self):
         return self.obj.everyone
@@ -133,7 +137,9 @@ class override_sample(_overrider):
             p = 0.0
         else:
             p = active
-        self.cls.objects.filter(pk=self.obj.pk).update(percent='{0}'.format(p))
+        obj = self.cls.objects.get(pk=self.obj.pk)
+        obj.percent = '{0}'.format(p)
+        obj.save()
 
     def get_value(self):
         p = self.obj.percent

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -19,26 +19,18 @@ def wafflejs(request):
 
 
 def _generate_waffle_js(request):
-    flags = cache.get(keyfmt(get_setting('ALL_FLAGS_CACHE_KEY')))
-    if flags is None:
-        flags = list(Flag.objects.values_list('name', flat=True))
-        cache.add(keyfmt(get_setting('ALL_FLAGS_CACHE_KEY')), flags)
-    flag_values = [(f, flag_is_active(request, f)) for f in flags]
+    flags = Flag.get_all()
+    flag_values = [(f.name, f.is_active(request)) for f in flags]
 
-    switches = cache.get(keyfmt(get_setting('ALL_SWITCHES_CACHE_KEY')))
-    if switches is None:
-        switches = list(Switch.objects.values_list('name', 'active'))
-        cache.add(keyfmt(get_setting('ALL_SWITCHES_CACHE_KEY')), switches)
+    switches = Switch.get_all()
+    switch_values = [(s.name, s.is_active()) for s in switches]
 
-    samples = cache.get(keyfmt(get_setting('ALL_SAMPLES_CACHE_KEY')))
-    if samples is None:
-        samples = list(Sample.objects.values_list('name', flat=True))
-        cache.add(keyfmt(get_setting('ALL_SAMPLES_CACHE_KEY')), samples)
-    sample_values = [(s, sample_is_active(s)) for s in samples]
+    samples = Sample.get_all()
+    sample_values = [(s.name, s.is_active()) for s in samples]
 
     return loader.render_to_string('waffle/waffle.js', {
         'flags': flag_values,
-        'switches': switches,
+        'switches': switch_values,
         'samples': sample_values,
         'flag_default': get_setting('FLAG_DEFAULT'),
         'switch_default': get_setting('SWITCH_DEFAULT'),


### PR DESCRIPTION
- Removes all signal handlers, fixes #137.
- Adds Cls.get_all() methods, fixes #142.
- Moves caching globally into Cls.get() and Cls.get_all(), fixes #170,
  fixes #160, fixes #77.
- Adds managers to invalidate ALL_\* cache keys on create.
- Adds a new delete admin action to invalidate cache.
- Adds Flag.is_active_for_user, fixes #186.
- Uses delete_many to flush cache, fixes #158.
- Fixes cache invalidation in override_*, fixes #163.
