### PR TITLE
Use strings for cache keys

### DIFF
--- a/docs/starting/configuring.rst
+++ b/docs/starting/configuring.rst
@@ -41,7 +41,8 @@ behavior.
     Waffle tries to store objects in cache pretty aggressively. If you
     ever upgrade and change the shape of the objects (for example
     upgrading from <0.7.5 to >0.7.5) you'll want to set this to
-    something other than ``'waffle:'``.
+    something other than ``'waffle:'``. If you're using memcached this should
+    be ASCII only, as that's all it supports.
 
 ``WAFFLE_CACHE_NAME``
     Which cache to use. Defaults to ``'default'``.

--- a/waffle/utils.py
+++ b/waffle/utils.py
@@ -22,7 +22,7 @@ def keyfmt(k, v=None):
         key = prefix + k
     else:
         key = prefix + hashlib.md5((k % v).encode('utf-8')).hexdigest()
-    return key.encode('utf-8')
+    return key
 
 
 def get_cache():


### PR DESCRIPTION
As discovered in YPlan/django-perf-rec#21, django-waffle is using `bytes` objects for cache keys. This seems to work with most of the caching infrastructure, but it's not documented as supported in the [Django cache docs](https://docs.djangoproject.com/en/1.10/topics/cache/) nor does it seem to be tested for in its test suite. Thus some cache backends may not support `bytes`, and `django-perf-rec` currently doesn't support them either.
