### PR TITLE
Travis - just run tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
 language: python
 sudo: false
-python:
- - "2.7"
- - "3.3"
- - "3.4"
- - "3.5"
- - "pypy"
-env:
- - DJANGO_VERSION="1.8"
- - DJANGO_VERSION="1.9"
+python: '3.5'
+
 install:
- - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99" -r travis.txt
-script: ./run.sh test
-matrix:
-  exclude:
-    - python: "3.3"
-      env: DJANGO_VERSION="1.9"
+ - pip install tox
+
+script:
+ - tox


### PR DESCRIPTION
Just run `tox` when on travis, meaning only one grid of Python versions versus Django versions needs be maintained, plus `tox` won't break whilst the build is 'passing'.
