### PR TITLE
Add Django 1.10.x test environment and fix broken tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ dist
 .project
 .pydevproject
 .settings
+.tox/
 docs/_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,7 @@
 language: python
 sudo: false
-python:
- - "2.7"
- - "3.3"
- - "3.4"
- - "3.5"
- - "pypy"
-env:
- - DJANGO_VERSION="1.8"
- - DJANGO_VERSION="1.9"
+python: "3.6"
 install:
- - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99" -r travis.txt
-script: ./run.sh test
-matrix:
-  exclude:
-    - python: "3.3"
-      env: DJANGO_VERSION="1.9"
+ - pip install tox
+script:
+ - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: python
+
 sudo: false
-python: "3.6"
+
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
 install:
- - pip install tox
+ - pip install tox tox-travis
+
 script:
  - tox

--- a/docs/starting/requirements.rst
+++ b/docs/starting/requirements.rst
@@ -39,7 +39,7 @@ processor`_::
 
     TEMPLATE_CONTEXT_PROCESSORS = (
         # ...
-        'django.core.context_processors.request',
+        'django.template.context_processors.request',
         # ...
 
 .. _template context processor: https://docs.djangoproject.com/en/dev/ref/settings/#template-context-processors

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,6 +1,5 @@
 from django.http import HttpResponse
-from django.shortcuts import render_to_response, render
-from django.template import Context, RequestContext
+from django.shortcuts import render
 from django.template.loader import render_to_string
 
 from waffle import flag_is_active
@@ -18,17 +17,16 @@ def flag_in_jinja(request):
 
 
 def flag_in_django(request):
-    c = RequestContext(request, {
+    context = {
         'flag_var': 'flag_var',
         'switch_var': 'switch_var',
         'sample_var': 'sample_var',
-    })
-    return render_to_response('django/django.html', context_instance=c)
+    }
+    return render(request, 'django/django.html', context=context)
 
 
 def no_request_context(request):
-    c = Context({})
-    return render_to_string('django/django_email.html', context_instance=c)
+    return render_to_string('django/django_email.html', context={})
 
 
 @waffle_switch('foo')

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,5 +1,9 @@
 import os
 import django
+from distutils.version import StrictVersion
+
+
+DJANGO_VERSION = StrictVersion(django.get_version())
 
 # Make filepaths relative to settings.
 ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -33,18 +37,24 @@ INSTALLED_APPS = (
     'test_app',
 )
 
-MIDDLEWARE_CLASSES = (
+_MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'waffle.middleware.WaffleMiddleware',
 )
 
+
+if DJANGO_VERSION < StrictVersion('1.10.0'):
+    MIDDLEWARE_CLASSES = _MIDDLEWARE_CLASSES
+else:
+    MIDDLEWARE = _MIDDLEWARE_CLASSES
+
 ROOT_URLCONF = 'test_app.urls'
 
 _CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.request',
+    'django.template.context_processors.request',
 )
 
 TEMPLATES = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,13 @@
 [tox]
 envlist =
-    py27-django{18,19},
-    py{33,34,35}-django{18,19}
+    py27-django{18,19,110},
+    py{33,34,35,36}-django{18,19,110}
 
 [testenv]
-    django18: Django>=1.8,<1.9 -rtravis.txt
-    django19: Django>=1.9,<1.10 -rtravis.txt
-commands = ./run.sh test
+deps =
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    -rtravis.txt
+commands =
+    ./run.sh test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py27-django{18,19,110},
-    py{33,34,35,36}-django{18,19,110}
+    py{27,33,34,35}-django18,
+    py{27,34,35}-django{19,110}
 
 [testenv]
 deps =


### PR DESCRIPTION
Hi James,

Just a small one here to get the project's test suite up to current speed.

Tox now runs the test suite successfully under the latest Django 1.10.x and Python 3.6 environments.

As part of making the tests run under the new environement, the tests were updated to account for deprecated behaviour in Django. Only thing of note really is that `render_to_response` was removed in favour of `render` as `render_to_response` is ['likely pending deprecation'](https://docs.djangoproject.com/en/1.10/topics/http/shortcuts/#render-to-response) as of Django 1.10.

Thanks for all your work on this, we use it extensively at Yunojuno. If the 1.10 stuff could get a release on PyPI that'd be super; if there's anything blocking that just let us know.

Fixes #224.

cheers,
Darian

