### PR TITLE
Get rid of reverse import DeprecationWarning 

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -1,9 +1,7 @@
 import os
 import django
-from distutils.version import StrictVersion
 
-
-DJANGO_VERSION = StrictVersion(django.get_version())
+DJANGO_VERSION = django.VERSION
 
 # Make filepaths relative to settings.
 ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -45,7 +43,7 @@ _MIDDLEWARE_CLASSES = (
 )
 
 
-if DJANGO_VERSION < StrictVersion('1.10.0'):
+if DJANGO_VERSION < (1, 10):
     MIDDLEWARE_CLASSES = _MIDDLEWARE_CLASSES
 else:
     MIDDLEWARE = _MIDDLEWARE_CLASSES

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
 envlist =
     py{27,33,34,35}-django18,
-    py{27,34,35}-django{19,110}
+    py{27,34,35}-django{19,110,111}
 
 [testenv]
 deps =
+    ipython
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11rc1,<2.0
     -rtravis.txt
 commands =
     ./run.sh test

--- a/waffle/decorators.py
+++ b/waffle/decorators.py
@@ -4,7 +4,10 @@ from functools import wraps
 
 from django.http import Http404
 from django.utils.decorators import available_attrs
-from django.core.urlresolvers import reverse, NoReverseMatch
+try:
+    from django.urls import reverse, NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import reverse, NoReverseMatch  # < django 1.10
 from django.shortcuts import redirect
 
 from waffle import flag_is_active, switch_is_active

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < django 1.10
 
 from waffle.models import Flag, Sample, Switch
 from waffle.tests.base import TestCase


### PR DESCRIPTION
Test against Django 1.11rc1
Forward-compatible django.urls import
Remove StrictVersion to allow support 1.11rc1, not-compatible with distutils