### PR TITLE
Implemented custom flag models

### DIFF
--- a/docs/starting/configuring.rst
+++ b/docs/starting/configuring.rst
@@ -12,9 +12,10 @@ behavior.
     Defaults to ``dwf_%s``.
 
 ``WAFFLE_FLAG_MODEL``
-    The model that will be use to keep track of flags. Defaults to ``waffle.Flag``
+    The model that will be used to keep track of flags. Defaults to ``waffle.Flag``
     which allows user- and group-based flags. Can be swapped for a different Flag model
-    that allows flagging based on other things, such as an Organization a user belongs to.
+    that allows flagging based on other relationships or properties, such as an Organization 
+    a user belongs to.
     Analogous functionality to Django's extendable User models.
     Needs to be set at the start of a project. Migrations do not support changing after the
     initial migration.

--- a/docs/starting/configuring.rst
+++ b/docs/starting/configuring.rst
@@ -11,6 +11,14 @@ behavior.
     The format for the cookies Waffle sets. Must contain ``%s``.
     Defaults to ``dwf_%s``.
 
+``WAFFLE_FLAG_MODEL``
+    The model that will be use to keep track of flags. Defaults to ``waffle.Flag``
+    which allows user- and group-based flags. Can be swapped for a different Flag model
+    that allows flagging based on other things, such as an Organization a user belongs to.
+    Analogous functionality to Django's extendable User models.
+    Needs to be set at the start of a project. Migrations do not support changing after the
+    initial migration.
+
 ``WAFFLE_FLAG_DEFAULT``
     When a Flag is undefined in the database, Waffle considers it
     ``False``.  Set this to ``True`` to make Waffle consider undefined

--- a/docs/types/flag.rst
+++ b/docs/types/flag.rst
@@ -86,6 +86,103 @@ are in the group *or* if they are in the 12%.
     probably differ slightly from the Percentage value.
 
 
+.. _types-flag-custom-model:
+
+Custom Flag Models
+======================
+
+For many cases, the default Flag model provides all the necessary functionality. It allows
+flagging individual Users and Groups. If you would like to flags be applied to different things,
+such as Companies a User belongs to, you can use a custom flag model for that.
+
+The functonality uses the same concepts as Django's custom user models, and a lot of this will
+be immediately recognizable.
+
+An application needs to define a ``WAFFLE_FLAG_MODEL`` settings. The default is ``waffle.Flag``
+but can be pointed to an arbitrary object.
+
+.. note::
+
+    It is not possible to change the Flag model and generate working migrations. Ideally, the flag
+    model should be defined at the start of a new project. This is a limitiation of the `swappable`
+    Django magic.
+
+The custom Flag model must inherit from `waffle.models.AbstractBaseFlag`. If you want the existing
+User and Group based flagging and would like to add more entities to it,
+you may extend `waffle.models.AbstractUserFlag`.
+
+If you need to refernce the class that is being used as the `Flag` model in your project, use the
+``get_waffle_flag_model()`` method. If you reference the Flag a lot, it may be convenient to add
+``Flag = get_waffle_flag_model()`` right blow your imports and refernce the Flag model as if it had
+been imported directly.
+
+Example:
+
+```python
+# settings.py
+WAFFLE_FLAG_MODEL = 'myapp.Flag'
+
+# models.py
+class Flag(AbstractUserFlag):
+    FLAG_COMPANIES_CACHE_KEY = 'FLAG_COMPANIES_CACHE_KEY'
+    COMPANY_FLAG_DEFAULTS = {FLAG_COMPANIES_CACHE_KEY: 'flag:%s:companies'}
+
+    companies = models.ManyToManyField(Company, blank=True, help_text=(
+        'Activate this flag for these companies.'))
+
+    class Meta(AbstractUserFlag.Meta):
+        verbose_name = 'Feature flag'
+
+    def get_flush_keys(self):
+        flush_keys = super(AbstractUserFlag, self).get_flush_keys()
+        companies_cache_key = get_setting(
+            Flag.FLAG_COMPANIES_CACHE_KEY,
+            more_defaults=Flag.COMPANY_FLAG_DEFAULTS
+        )
+        flush_keys.append(keyfmt(companies_cache_key, self.name))
+        return flush_keys
+
+    def is_active_for_user(self, user):
+        is_active = super(Flag, self).is_active_for_user(user)
+        if is_active:
+            return is_active
+
+        company_ids = self._get_company_ids()
+        if hasattr(user, 'company_id') and user.company_id in company_ids:
+            return True
+
+    def _get_company_ids(self):
+        cache_key = keyfmt(
+            get_setting(
+                Flag.FLAG_COMPANIES_CACHE_KEY,
+                more_defaults=Flag.COMPANY_FLAG_DEFAULTS)
+            ,
+            self.name
+        )
+        cached = cache.get(cache_key)
+        if cached == CACHE_EMPTY:
+            return set()
+        if cached:
+            return cached
+
+        company_ids = set(self.companies.all().values_list('pk', flat=True))
+        if not company_ids:
+            cache.add(cache_key, CACHE_EMPTY)
+            return set()
+
+        cache.add(cache_key, company_ids)
+        return company_ids
+
+# admin.py
+from waffle.admin import FlagAdmin as WaffleFlagAdmin
+
+class FlagAdmin(WaffleFlagAdmin):
+    raw_id_fields = tuple(list(WaffleFlagAdmin.raw_id_fields) + ['companies'])
+admin.site.register(Flag, FlagAdmin)
+
+```
+
+
 .. _types-flag-testing:
 
 Testing Mode

--- a/docs/types/flag.rst
+++ b/docs/types/flag.rst
@@ -92,8 +92,10 @@ Custom Flag Models
 ======================
 
 For many cases, the default Flag model provides all the necessary functionality. It allows
-flagging individual Users and Groups. If you would like to flags be applied to different things,
-such as Companies a User belongs to, you can use a custom flag model for that.
+flagging individual Users and Groups. If you would like flags be applied to different things,
+such as Companies a User belongs to, you can use a custom flag model for that. You could flag
+on any relationship or property that can be derived from request.user. Other possible ideas
+is to apply flags based on the user's language or IP address.
 
 The functonality uses the same concepts as Django's custom user models, and a lot of this will
 be immediately recognizable.
@@ -104,7 +106,7 @@ but can be pointed to an arbitrary object.
 .. note::
 
     It is not possible to change the Flag model and generate working migrations. Ideally, the flag
-    model should be defined at the start of a new project. This is a limitiation of the `swappable`
+    model should be defined at the start of a new project. This is a limitation of the `swappable`
     Django magic.
 
 The custom Flag model must inherit from `waffle.models.AbstractBaseFlag`. If you want the existing
@@ -113,7 +115,7 @@ you may extend `waffle.models.AbstractUserFlag`.
 
 If you need to refernce the class that is being used as the `Flag` model in your project, use the
 ``get_waffle_flag_model()`` method. If you reference the Flag a lot, it may be convenient to add
-``Flag = get_waffle_flag_model()`` right blow your imports and refernce the Flag model as if it had
+``Flag = get_waffle_flag_model()`` right below your imports and refernce the Flag model as if it had
 been imported directly.
 
 Example:

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -1,8 +1,11 @@
 from __future__ import unicode_literals
 
-from decimal import Decimal
 import random
+from decimal import Decimal
 
+from django.apps import apps as django_apps
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from waffle.utils import get_setting, keyfmt, get_cache
 
 
@@ -11,9 +14,7 @@ __version__ = '.'.join(map(str, VERSION))
 
 
 def flag_is_active(request, flag_name):
-    from .models import Flag
-
-    flag = Flag.get(flag_name)
+    flag = get_waffle_flag_model().get(flag_name)
     return flag.is_active(request)
 
 
@@ -29,3 +30,25 @@ def sample_is_active(sample_name):
 
     sample = Sample.get(sample_name)
     return sample.is_active()
+
+
+def get_waffle_flag_model():
+    """
+    Returns the waffle Flag model that is active in this project.
+    """
+    # Add backwards compatibility by not requiring adding of WAFFLE_FLAG_MODEL
+    # for everyone who upgrades
+    # At some point it would be helpful to require this to be defined explicitly, but no for now, to
+    # remove pain form upgrading.
+    flag_model = getattr(settings, 'WAFFLE_FLAG_MODEL', 'waffle.Flag')
+
+    try:
+        return django_apps.get_model(flag_model)
+    except ValueError:
+        raise ImproperlyConfigured("WAFFLE_FLAG_MODEL must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise ImproperlyConfigured(
+            "WAFFLE_FLAG_MODEL refers to model '{}' that has not been installed".format(
+                settings.WAFFLE_FLAG_MODEL
+            )
+        )

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -36,10 +36,9 @@ def get_waffle_flag_model():
     """
     Returns the waffle Flag model that is active in this project.
     """
-    # Add backwards compatibility by not requiring adding of WAFFLE_FLAG_MODEL
-    # for everyone who upgrades
-    # At some point it would be helpful to require this to be defined explicitly, but no for now, to
-    # remove pain form upgrading.
+    # Assume default WAFFLE_FLAG_MODEL.
+    # At some point it would be helpful to require this to be defined explicitly, but not for now
+    # This remove pain from upgrading.
     flag_model = getattr(settings, 'WAFFLE_FLAG_MODEL', 'waffle.Flag')
 
     try:

--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -36,11 +36,14 @@ def delete_individually(ma, request, qs):
 delete_individually.short_description = 'Delete selected.'
 
 
-class FlagAdmin(BaseAdmin):
+class AbstractFlagAdmin(BaseAdmin):
     actions = [enable_for_all, disable_for_all, delete_individually]
     list_display = ('name', 'note', 'everyone', 'percent', 'superusers',
                     'staff', 'authenticated', 'languages')
     list_filter = ('everyone', 'superusers', 'staff', 'authenticated')
+    ordering = ('-id',)
+
+class FlagAdmin(AbstractFlagAdmin):
     raw_id_fields = ('users', 'groups')
     ordering = ('-id',)
 

--- a/waffle/management/commands/waffle_flag.py
+++ b/waffle/management/commands/waffle_flag.py
@@ -4,7 +4,7 @@ from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
 
-from waffle.models import Flag
+from waffle import get_waffle_flag_model
 
 
 class Command(BaseCommand):
@@ -59,6 +59,7 @@ class Command(BaseCommand):
     args = "<flag_name>"
 
     def handle(self, flag_name=None, *args, **options):
+        Flag = get_waffle_flag_model()
         list_flag = options['list_flag']
 
         if list_flag:

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -98,7 +98,7 @@ def set_flag(request, flag_name, active=True, session_only=False):
     request.waffles[flag_name] = [active, session_only]
 
 
-class Flag(BaseModel):
+class AbstractBaseFlag(BaseModel):
     """A feature flag.
 
     Flags are active (or not) on a per-request basis.
@@ -124,10 +124,6 @@ class Flag(BaseModel):
     languages = models.TextField(blank=True, default='', help_text=(
         'Activate this flag for users with one of these languages (comma '
         'separated list)'))
-    groups = models.ManyToManyField(Group, blank=True, help_text=(
-        'Activate this flag for these user groups.'))
-    users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True,
-        help_text=('Activate this flag for these users.'))
     rollout = models.BooleanField(default=False, help_text=(
         'Activate roll-out mode?'))
     note = models.TextField(blank=True, help_text=(
@@ -142,46 +138,18 @@ class Flag(BaseModel):
     SINGLE_CACHE_KEY = 'FLAG_CACHE_KEY'
     ALL_CACHE_KEY = 'ALL_FLAGS_CACHE_KEY'
 
+    class Meta:
+        abstract = True
+
     def flush(self):
-        keys = [
-            self._cache_key(self.name),
-            keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), self.name),
-            keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), self.name),
-            get_setting('ALL_FLAGS_CACHE_KEY'),
-        ]
+        keys = self.get_flush_keys()
         cache.delete_many(keys)
 
-    def _get_user_ids(self):
-        cache_key = keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), self.name)
-        cached = cache.get(cache_key)
-        if cached == CACHE_EMPTY:
-            return set()
-        if cached:
-            return cached
-
-        user_ids = set(self.users.all().values_list('pk', flat=True))
-        if not user_ids:
-            cache.add(cache_key, CACHE_EMPTY)
-            return set()
-
-        cache.add(cache_key, user_ids)
-        return user_ids
-
-    def _get_group_ids(self):
-        cache_key = keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), self.name)
-        cached = cache.get(cache_key)
-        if cached == CACHE_EMPTY:
-            return set()
-        if cached:
-            return cached
-
-        group_ids = set(self.groups.all().values_list('pk', flat=True))
-        if not group_ids:
-            cache.add(cache_key, CACHE_EMPTY)
-            return set()
-
-        cache.add(cache_key, group_ids)
-        return group_ids
+    def get_flush_keys(self):
+        return [
+            self._cache_key(self.name),
+            get_setting('ALL_FLAGS_CACHE_KEY'),
+        ]
 
     def is_active_for_user(self, user):
         authed = getattr(user, 'is_authenticated', lambda: False)()
@@ -194,15 +162,6 @@ class Flag(BaseModel):
         if self.superusers and getattr(user, 'is_superuser', False):
             return True
 
-        user_ids = self._get_user_ids()
-        if hasattr(user, 'pk') and user.pk in user_ids:
-            return True
-
-        if hasattr(user, 'groups'):
-            group_ids = self._get_group_ids()
-            user_groups = set(user.groups.all().values_list('pk', flat=True))
-            if group_ids.intersection(user_groups):
-                return True
         return None
 
     def _is_active_for_user(self, request):
@@ -268,6 +227,80 @@ class Flag(BaseModel):
         return False
 
 
+class AbstractUserFlag(AbstractBaseFlag):
+    FLAG_USERS_CACHE_KEY = 'FLAG_USERS_CACHE_KEY'
+    FLAG_GROUPS_CACHE_KEY = 'FLAG_GROUPS_CACHE_KEY'
+
+    groups = models.ManyToManyField(Group, blank=True, help_text=(
+        'Activate this flag for these user groups.'))
+    users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True,
+                                   help_text=('Activate this flag for these users.'))
+
+    class Meta(AbstractBaseFlag.Meta):
+        abstract = True
+
+    def get_flush_keys(self):
+        flush_keys = super(AbstractUserFlag, self).get_flush_keys()
+        flush_keys.extend([
+            keyfmt(get_setting(Flag.FLAG_USERS_CACHE_KEY), self.name),
+            keyfmt(get_setting(Flag.FLAG_GROUPS_CACHE_KEY), self.name),
+        ])
+        return flush_keys
+
+    def is_active_for_user(self, user):
+        is_active = super(AbstractUserFlag, self).is_active_for_user(user)
+        if is_active:
+            return is_active
+
+        user_ids = self._get_user_ids()
+        if hasattr(user, 'pk') and user.pk in user_ids:
+            return True
+
+        if hasattr(user, 'groups'):
+            group_ids = self._get_group_ids()
+            user_groups = set(user.groups.all().values_list('pk', flat=True))
+            if group_ids.intersection(user_groups):
+                return True
+        return None
+
+    def _get_user_ids(self):
+        cache_key = keyfmt(get_setting(Flag.FLAG_USERS_CACHE_KEY), self.name)
+        cached = cache.get(cache_key)
+        if cached == CACHE_EMPTY:
+            return set()
+        if cached:
+            return cached
+
+        user_ids = set(self.users.all().values_list('pk', flat=True))
+        if not user_ids:
+            cache.add(cache_key, CACHE_EMPTY)
+            return set()
+
+        cache.add(cache_key, user_ids)
+        return user_ids
+
+    def _get_group_ids(self):
+        cache_key = keyfmt(get_setting(Flag.FLAG_GROUPS_CACHE_KEY), self.name)
+        cached = cache.get(cache_key)
+        if cached == CACHE_EMPTY:
+            return set()
+        if cached:
+            return cached
+
+        group_ids = set(self.groups.all().values_list('pk', flat=True))
+        if not group_ids:
+            cache.add(cache_key, CACHE_EMPTY)
+            return set()
+
+        cache.add(cache_key, group_ids)
+        return group_ids
+
+
+class Flag(AbstractUserFlag):
+    class Meta(AbstractUserFlag.Meta):
+        swappable = 'WAFFLE_FLAG_MODEL'
+
+
 class Switch(BaseModel):
     """A feature switch.
 
@@ -324,3 +357,4 @@ class Sample(BaseModel):
         if not self.pk:
             return get_setting('SAMPLE_DEFAULT')
         return Decimal(str(random.uniform(0, 100))) <= self.percent
+

--- a/waffle/tests/test_decorators.py
+++ b/waffle/tests/test_decorators.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 
-from waffle.models import Flag, Switch
+from waffle import get_waffle_flag_model
+from waffle.models import Switch
 from waffle.tests.base import TestCase
+
+Flag = get_waffle_flag_model()
 
 
 class DecoratorTests(TestCase):

--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -6,8 +6,11 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase, RequestFactory
 
 import waffle
-from waffle.models import Switch, Flag, Sample
+from waffle import get_waffle_flag_model
+from waffle.models import Switch, Sample
 from waffle.testutils import override_switch, override_flag, override_sample
+
+Flag = get_waffle_flag_model()
 
 
 class OverrideSwitchTests(TestCase):

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -2,8 +2,11 @@ from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
 
-from waffle.models import Flag, Sample, Switch
+from waffle import get_waffle_flag_model
+from waffle.models import Sample, Switch
 from waffle.tests.base import TestCase
+
+Flag = get_waffle_flag_model()
 
 
 class WaffleViewTests(TestCase):

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -11,9 +11,12 @@ import mock
 
 import waffle
 from test_app import views
+from waffle import get_waffle_flag_model
 from waffle.middleware import WaffleMiddleware
-from waffle.models import Flag, Sample, Switch
+from waffle.models import Sample, Switch
 from waffle.tests.base import TestCase
+
+Flag = get_waffle_flag_model()
 
 
 def get(**kw):

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -4,7 +4,8 @@ import sys
 import types
 from functools import wraps
 
-from waffle.models import Flag, Switch, Sample
+from waffle.models import Switch, Sample
+from waffle import get_waffle_flag_model
 
 
 __all__ = ['override_flag', 'override_sample', 'override_switch']
@@ -108,7 +109,7 @@ class override_switch(_overrider):
 
 
 class override_flag(_overrider):
-    cls = Flag
+    cls = get_waffle_flag_model()
 
     def update(self, active):
         obj = self.cls.objects.get(pk=self.obj.pk)

--- a/waffle/utils.py
+++ b/waffle/utils.py
@@ -9,11 +9,20 @@ import waffle
 from waffle import defaults
 
 
-def get_setting(name):
+def get_setting(name, more_defaults=None):
+    """
+    :param name: Name of WAFFLE_* setting (value of *) to get from settings or waffle.defaults
+    :param more_defaults: additional app-defined defaults
+    :return: the setting value
+    """
     try:
         return getattr(settings, 'WAFFLE_' + name)
     except AttributeError:
-        return getattr(defaults, name)
+        try:
+            return getattr(defaults, name)
+        except AttributeError:
+            more_defaults = more_defaults or {}
+            return more_defaults[name]
 
 
 def keyfmt(k, v=None):

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -4,8 +4,8 @@ from django.http import HttpResponse
 from django.template import loader
 from django.views.decorators.cache import never_cache
 
-from waffle import flag_is_active, sample_is_active
-from waffle.models import Flag, Sample, Switch
+from waffle import flag_is_active, sample_is_active, get_waffle_flag_model
+from waffle.models import Sample, Switch
 from waffle.utils import get_setting, keyfmt, get_cache
 
 
@@ -19,7 +19,7 @@ def wafflejs(request):
 
 
 def _generate_waffle_js(request):
-    flags = Flag.get_all()
+    flags = get_waffle_flag_model().get_all()
     flag_values = [(f.name, f.is_active(request)) for f in flags]
 
     switches = Switch.get_all()


### PR DESCRIPTION
Allows application to provide it's drop-in replacement of Waffle's flag which allows flagging on entities other than Users and Groups. Opens possibility to flag on Company or Organization, or any other property that can be derived from `request.user`.

Fixes https://github.com/jsocol/django-waffle/issues/181

Based on Django's custom user models and guidance from https://github.com/freakboy3742



