### PR TITLE
Add groups to waffle_flag management command

### DIFF
--- a/waffle/management/commands/waffle_flag.py
+++ b/waffle/management/commands/waffle_flag.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand, CommandError
 
 from waffle.models import Flag
@@ -29,7 +30,8 @@ class Command(BaseCommand):
             action='store',
             type=int,
             dest='percent',
-            help='Roll out the flag for a certain percentage of users. Takes a number between 0.0 and 100.0'),
+            help='Roll out the flag for a certain percentage of users. Takes '
+                 'a number between 0.0 and 100.0'),
         parser.add_argument(
             '--superusers',
             action='store_true',
@@ -48,6 +50,20 @@ class Command(BaseCommand):
             dest='authenticated',
             default=False,
             help='Turn on the flag for logged in users.'),
+        parser.add_argument(
+            '--group', '-g',
+            action='append',
+            default=list(),
+            # dest='group_name',
+            help='Turn on the flag for listed group names (use flag more '
+                 'than once for multiple groups). WARNING: This will remove '
+                 'any currently associated groups unless --append is used!'),
+        parser.add_argument(
+            '--append',
+            action='store_true',
+            dest='append',
+            default=False,
+            help='Append only mode when adding groups.'),
         parser.add_argument(
             '--rollout', '-r',
             action='store_true',
@@ -75,6 +91,9 @@ class Command(BaseCommand):
                 self.stdout.write('TESTING: %s' % flag.testing)
                 self.stdout.write('ROLLOUT: %s' % flag.rollout)
                 self.stdout.write('STAFF: %s' % flag.staff)
+                self.stdout.write('GROUPS: %s' % list(
+                    flag.groups.values_list('name', flat=True))
+                )
                 self.stdout.write('')
             return
 
@@ -93,7 +112,26 @@ class Command(BaseCommand):
         # Loop through all options, setting Flag attributes that
         # match (ie. don't want to try setting flag.verbosity)
         for option in options:
-            if hasattr(flag, option):
+            # Group isn't an attribute on the Flag, but a related Many to Many
+            # field, so we handle it a bit differently by looking up groups and
+            # adding each group to the flag individually
+            if option == 'group':
+                group_hash = {}
+                for group in options['group']:
+                    try:
+                        group_instance = Group.objects.get(name=group)
+                        group_hash[group_instance.name] = group_instance.id
+                    except Group.DoesNotExist:
+                        raise CommandError("Group %s doesn't exist" % group)
+                # If 'append' was not passed, we clear related groups
+                if not options['append']:
+                    flag.groups.clear()
+                self.stdout.write('Setting group(s): %s' % (
+                    [name for name, _id in group_hash.items()])
+                )
+                for group_name, group_id in group_hash.items():
+                    flag.groups.add(group_id)
+            elif hasattr(flag, option):
                 self.stdout.write('Setting %s: %s' % (option, options[option]))
                 setattr(flag, option, options[option])
 


### PR DESCRIPTION
This solves issue https://github.com/jsocol/django-waffle/issues/222.

This updates the `waffle_flag` management command to take multiple `--groups` or `-g` arguments for attaching Django permission groups to a Waffle flag. By default it will clear existing groups attached to the flag. However, this also adds an `--append` flag, which will alternatively append groups to the Waffle flag.

Additionally I updated a few flake8 errors, and added a test for the command.