### PR TITLE
Fixed some broken links in the documentation

### DIFF
--- a/docs/types/flag.rst
+++ b/docs/types/flag.rst
@@ -50,7 +50,7 @@ Flags can be administered through the Django `admin site`_ or the
     *Unknown* to use other critera.
 :Testing:
     Can the flag be specified via a querystring parameter? :ref:`See
-    below <types-flag-testing`.
+    below <types-flag-testing>`.
 :Percent:
     A percentage of users for whom the flag will be active, if no other
     criteria applies to them.

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -6,7 +6,7 @@ Using Waffle
 
 Waffle provides a simple API to check the state of :ref:`flags
 <types-flag>`, :ref:`switches <types-switch>`, and :ref:`samples
-<types-samples>` in views and templates, and even on the client in
+<types-sample>` in views and templates, and even on the client in
 JavaScript.
 
 .. toctree::


### PR DESCRIPTION
This fixes a couple of typos in the documentation that were breaking links to elsewhere in the docs.