### PR TITLE
Fix Flake8 errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,4 @@ universal = 1
 
 [flake8]
 exclude=waffle/migrations/*,waffle/south_migrations/*
+ignore=E731

--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -18,7 +18,6 @@ def enable_for_all(ma, request, qs):
     for f in qs.all():
         f.everyone = True
         f.save()
-enable_for_all.short_description = 'Enable selected flags for everyone.'
 
 
 def disable_for_all(ma, request, qs):
@@ -26,13 +25,16 @@ def disable_for_all(ma, request, qs):
     for f in qs.all():
         f.everyone = False
         f.save()
-disable_for_all.short_description = 'Disable selected flags for everyone.'
 
 
 def delete_individually(ma, request, qs):
     # Iterate over all objects to cause cache invalidation.
     for f in qs.all():
         f.delete()
+
+
+enable_for_all.short_description = 'Enable selected flags for everyone.'
+disable_for_all.short_description = 'Disable selected flags for everyone.'
 delete_individually.short_description = 'Delete selected.'
 
 
@@ -49,13 +51,15 @@ def enable_switches(ma, request, qs):
     for switch in qs:
         switch.active = True
         switch.save()
-enable_switches.short_description = 'Enable the selected switches.'
 
 
 def disable_switches(ma, request, qs):
     for switch in qs:
         switch.active = False
         switch.save()
+
+
+enable_switches.short_description = 'Enable the selected switches.'
 disable_switches.short_description = 'Disable the selected switches.'
 
 

--- a/waffle/decorators.py
+++ b/waffle/decorators.py
@@ -57,4 +57,3 @@ def get_response_to_redirect(view):
         return redirect(reverse(view)) if view else None
     except NoReverseMatch:
         return None
-

--- a/waffle/management/commands/waffle_sample.py
+++ b/waffle/management/commands/waffle_sample.py
@@ -33,7 +33,9 @@ class Command(BaseCommand):
         percent = options['positionals'][1]
 
         if not (sample_name and percent):
-            raise CommandError('You need to specify a sample name and percentage.')
+            raise CommandError(
+                'You need to specify a sample name and percentage.'
+            )
 
         try:
             percent = float(percent)

--- a/waffle/management/commands/waffle_switch.py
+++ b/waffle/management/commands/waffle_switch.py
@@ -23,7 +23,9 @@ class Command(BaseCommand):
         if options['list_switches']:
             self.stdout.write('Switches:')
             for switch in Switch.objects.iterator():
-                self.stdout.write('%s: %s' % (switch.name, 'on' if switch.active else 'off'))
+                self.stdout.write(
+                    '%s: %s' % (switch.name, 'on' if switch.active else 'off')
+                )
             self.stdout.write('')
             return
 
@@ -35,17 +37,21 @@ class Command(BaseCommand):
             raise CommandError('You need to specify a switch name and state.')
 
         if state not in ['on', 'off']:
-            raise CommandError('You need to specify state of switch with "on" or "off".')
+            raise CommandError(
+                'You need to specify state of switch with "on" or "off".'
+            )
 
         active = state == "on"
         defaults = {'active': active}
 
         if options['create']:
-            switch, created = Switch.objects.get_or_create(name=switch_name, defaults=defaults)
+            switch, created = Switch.objects.get_or_create(name=switch_name,
+                                                           defaults=defaults)
             if created:
                 self.stdout.write('Creating switch: %s' % switch_name)
         else:
             try:
-                switch = Switch.objects.update_or_create(name=switch_name, defaults=defaults)
+                switch = Switch.objects.update_or_create(name=switch_name,
+                                                         defaults=defaults)
             except Switch.DoesNotExist:
                 raise CommandError("This switch doesn't exist.")

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -104,15 +104,17 @@ class Flag(BaseModel):
     Flags are active (or not) on a per-request basis.
 
     """
+
     name = models.CharField(max_length=100, unique=True,
                             help_text='The human/computer readable name.')
     everyone = models.NullBooleanField(blank=True, help_text=(
         'Flip this flag on (Yes) or off (No) for everyone, overriding all '
         'other settings. Leave as Unknown to use normally.'))
-    percent = models.DecimalField(max_digits=3, decimal_places=1, null=True,
-                                  blank=True, help_text=(
-        'A number between 0.0 and 99.9 to indicate a percentage of users for '
-        'whom this flag will be active.'))
+    percent = models.DecimalField(
+        max_digits=3, decimal_places=1, null=True, blank=True,
+        help_text=('A number between 0.0 and 99.9 to indicate a percentage of '
+                   'users for whom this flag will be active.')
+    )
     testing = models.BooleanField(default=False, help_text=(
         'Allow this flag to be set for a session for user testing.'))
     superusers = models.BooleanField(default=True, help_text=(
@@ -126,14 +128,18 @@ class Flag(BaseModel):
         'separated list)'))
     groups = models.ManyToManyField(Group, blank=True, help_text=(
         'Activate this flag for these user groups.'))
-    users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True,
-        help_text=('Activate this flag for these users.'))
+    users = models.ManyToManyField(
+        settings.AUTH_USER_MODEL, blank=True,
+        help_text=('Activate this flag for these users.')
+    )
     rollout = models.BooleanField(default=False, help_text=(
         'Activate roll-out mode?'))
     note = models.TextField(blank=True, help_text=(
         'Note where this Flag is used.'))
-    created = models.DateTimeField(default=datetime.now, db_index=True,
-        help_text=('Date when this Flag was created.'))
+    created = models.DateTimeField(
+        default=datetime.now, db_index=True,
+        help_text=('Date when this Flag was created.')
+    )
     modified = models.DateTimeField(default=datetime.now, help_text=(
         'Date when this Flag was last modified.'))
 
@@ -274,14 +280,17 @@ class Switch(BaseModel):
     Switches are active, or inactive, globally.
 
     """
+
     name = models.CharField(max_length=100, unique=True,
                             help_text='The human/computer readable name.')
     active = models.BooleanField(default=False, help_text=(
         'Is this switch active?'))
     note = models.TextField(blank=True, help_text=(
         'Note where this Switch is used.'))
-    created = models.DateTimeField(default=datetime.now, db_index=True,
-        help_text=('Date when this Switch was created.'))
+    created = models.DateTimeField(
+        default=datetime.now, db_index=True,
+        help_text=('Date when this Switch was created.')
+    )
     modified = models.DateTimeField(default=datetime.now, help_text=(
         'Date when this Switch was last modified.'))
 
@@ -300,9 +309,13 @@ class Switch(BaseModel):
 
 
 class Sample(BaseModel):
-    """A sample is true some percentage of the time, but is not connected
+    """A sample of users.
+
+    A sample is true some percentage of the time, but is not connected
     to users or requests.
+
     """
+
     name = models.CharField(max_length=100, unique=True,
                             help_text='The human/computer readable name.')
     percent = models.DecimalField(max_digits=4, decimal_places=1, help_text=(
@@ -310,8 +323,10 @@ class Sample(BaseModel):
         'this sample will be active.'))
     note = models.TextField(blank=True, help_text=(
         'Note where this Sample is used.'))
-    created = models.DateTimeField(default=datetime.now, db_index=True,
-        help_text=('Date when this Sample was created.'))
+    created = models.DateTimeField(
+        default=datetime.now, db_index=True,
+        help_text=('Date when this Sample was created.')
+    )
     modified = models.DateTimeField(default=datetime.now, help_text=(
         'Date when this Sample was last modified.'))
 

--- a/waffle/tests/test_templates.py
+++ b/waffle/tests/test_templates.py
@@ -35,8 +35,15 @@ class WaffleTemplateTests(TestCase):
         self.assertContains(response, 'window.waffle =')
 
     def test_get_nodes_by_type(self):
-        """WaffleNode.get_nodes_by_type() should correctly find all child nodes"""
-        test_template = Template('{% load waffle_tags %}{% switch "x" %}{{ a }}{% else %}{{ b }}{% endswitch %}')
+        """WaffleNode.get_nodes_by_type() should find all child nodes."""
+        test_template = Template(
+            '{% load waffle_tags %}'
+            '{% switch "x" %}'
+            '{{ a }}'
+            '{% else %}'
+            '{{ b }}'
+            '{% endswitch %}'
+        )
         children = test_template.nodelist.get_nodes_by_type(VariableNode)
         self.assertEqual(len(children), 2)
 

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -298,7 +298,7 @@ class SwitchTests(TestCase):
         assert waffle.switch_is_active(switch.name)
         queries = len(connection.queries)
         assert waffle.switch_is_active(switch.name)
-        self.assertEqual(queries, len(connection.queries), 'We should only make one query.')
+        self.assertEqual(queries, len(connection.queries))
 
     def test_switch_inactive_from_cache(self):
         """Do not make two queries for an existing inactive switch."""
@@ -307,7 +307,7 @@ class SwitchTests(TestCase):
         assert not waffle.switch_is_active(switch.name)
         queries = len(connection.queries)
         assert not waffle.switch_is_active(switch.name)
-        self.assertEqual(queries, len(connection.queries), 'We should only make one query.')
+        self.assertEqual(queries, len(connection.queries))
 
     def test_undefined(self):
         assert not waffle.switch_is_active('foo')
@@ -322,10 +322,10 @@ class SwitchTests(TestCase):
         assert not Switch.objects.filter(name='foo').exists()
         queries = len(connection.queries)
         assert not waffle.switch_is_active('foo')
-        assert len(connection.queries) > queries, 'We should make one query.'
+        assert len(connection.queries) > queries
         queries = len(connection.queries)
         assert not waffle.switch_is_active('foo')
-        self.assertEqual(queries, len(connection.queries), 'We should only make one query.')
+        self.assertEqual(queries, len(connection.queries))
 
 
 class SampleTests(TestCase):


### PR DESCRIPTION
This fixes many of the previous flake8 errors that were present. A few `# noqa` lines were added where they make sense. I did not remove any of the unused imports, as I wasn't entirely sure if they were there for a good reason I'm not aware of. That being said, I'm happy to remove them if they aren't there for a good reason (or add a `# noqa` to exclude them from flake8 if they are needed). The remaining errors are below.

```
waffle/__init__.py:3:1: F401 'decimal.Decimal' imported but unused
waffle/__init__.py:4:1: F401 'random' imported but unused
waffle/__init__.py:6:1: F401 'waffle.utils.keyfmt' imported but unused
waffle/__init__.py:6:1: F401 'waffle.utils.get_cache' imported but unused
waffle/__init__.py:6:1: F401 'waffle.utils.get_setting' imported but unused
waffle/models.py:14:1: F401 'django.db.models.signals.m2m_changed' imported but unused
waffle/models.py:14:1: F401 'django.db.models.signals.post_save' imported but unused
waffle/models.py:14:1: F401 'django.db.models.signals.post_delete' imported but unused
waffle/views.py:7:1: F401 'waffle.sample_is_active' imported but unused
waffle/views.py:7:1: F401 'waffle.flag_is_active' imported but unused
waffle/views.py:9:1: F401 'waffle.utils.keyfmt' imported but unused
```