### PR TITLE
Cleanup and fix management commands (re-creation of PR #256)

### DIFF
--- a/waffle/management/commands/waffle_flag.py
+++ b/waffle/management/commands/waffle_flag.py
@@ -8,74 +8,76 @@ from waffle.models import Flag
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument('name', nargs='?')
+        parser.add_argument(
+            'name',
+            nargs='?',
+            help='The name of the flag.')
         parser.add_argument(
             '-l', '--list',
             action='store_true',
             dest='list_flags',
             default=False,
-            help="List existing samples."),
+            help='List existing samples.')
         parser.add_argument(
             '--everyone',
             action='store_true',
             dest='everyone',
-            help="Activate flag for all users."),
+            help='Activate flag for all users.')
         parser.add_argument(
             '--deactivate',
             action='store_false',
             dest='everyone',
-            help="Deactivate flag for all users."),
+            help='Deactivate flag for all users.')
         parser.add_argument(
             '--percent', '-p',
             action='store',
             type=int,
             dest='percent',
             help='Roll out the flag for a certain percentage of users. Takes '
-                 'a number between 0.0 and 100.0'),
+                 'a number between 0.0 and 100.0')
         parser.add_argument(
             '--superusers',
             action='store_true',
             dest='superusers',
             default=False,
-            help='Turn on the flag for Django superusers.'),
+            help='Turn on the flag for Django superusers.')
         parser.add_argument(
             '--staff',
             action='store_true',
             dest='staff',
             default=False,
-            help='Turn on the flag for Django staff.'),
+            help='Turn on the flag for Django staff.')
         parser.add_argument(
             '--authenticated',
             action='store_true',
             dest='authenticated',
             default=False,
-            help='Turn on the flag for logged in users.'),
+            help='Turn on the flag for logged in users.')
         parser.add_argument(
             '--group', '-g',
             action='append',
             default=list(),
-            # dest='group_name',
             help='Turn on the flag for listed group names (use flag more '
                  'than once for multiple groups). WARNING: This will remove '
-                 'any currently associated groups unless --append is used!'),
+                 'any currently associated groups unless --append is used!')
         parser.add_argument(
             '--append',
             action='store_true',
             dest='append',
             default=False,
-            help='Append only mode when adding groups.'),
+            help='Append only mode when adding groups.')
         parser.add_argument(
             '--rollout', '-r',
             action='store_true',
             dest='rollout',
             default=False,
-            help='Turn on rollout mode.'),
+            help='Turn on rollout mode.')
         parser.add_argument(
             '--create',
             action='store_true',
             dest='create',
             default=False,
-            help='If the flag doesn\'t exist, create it.'),
+            help='If the flag doesn\'t exist, create it.')
 
     help = 'Modify a flag.'
 
@@ -99,6 +101,9 @@ class Command(BaseCommand):
 
         flag_name = options['name']
 
+        if not flag_name:
+            raise CommandError('You need to specify a flag name.')
+
         if options['create']:
             flag, created = Flag.objects.get_or_create(name=flag_name)
             if created:
@@ -107,7 +112,7 @@ class Command(BaseCommand):
             try:
                 flag = Flag.objects.get(name=flag_name)
             except Flag.DoesNotExist:
-                raise CommandError("This flag doesn't exist")
+                raise CommandError('This flag does not exist.')
 
         # Loop through all options, setting Flag attributes that
         # match (ie. don't want to try setting flag.verbosity)
@@ -122,7 +127,7 @@ class Command(BaseCommand):
                         group_instance = Group.objects.get(name=group)
                         group_hash[group_instance.name] = group_instance.id
                     except Group.DoesNotExist:
-                        raise CommandError("Group %s doesn't exist" % group)
+                        raise CommandError('Group %s does not exist' % group)
                 # If 'append' was not passed, we clear related groups
                 if not options['append']:
                     flag.groups.clear()

--- a/waffle/management/commands/waffle_sample.py
+++ b/waffle/management/commands/waffle_sample.py
@@ -7,17 +7,25 @@ from waffle.models import Sample
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument('positionals', nargs='*')
+        parser.add_argument(
+            'name',
+            nargs='?',
+            help='The name of the sample.')
+        parser.add_argument(
+            'percent',
+            nargs='?',
+            type=int,
+            help='The percentage of the time this sample will be active.')
         parser.add_argument(
             '-l', '--list',
             action='store_true', dest='list_samples', default=False,
-            help='List existing samples.'),
+            help='List existing samples.')
         parser.add_argument(
             '--create',
             action='store_true',
             dest='create',
             default=False,
-            help="If the sample doesn't exist, create it."),
+            help='If the sample does not exist, create it.')
 
     help = 'Change percentage of a sample.'
 
@@ -29,8 +37,8 @@ class Command(BaseCommand):
             self.stdout.write('')
             return
 
-        sample_name = options['positionals'][0]
-        percent = options['positionals'][1]
+        sample_name = options['name']
+        percent = options['percent']
 
         if not (sample_name and percent):
             raise CommandError(

--- a/waffle/management/commands/waffle_switch.py
+++ b/waffle/management/commands/waffle_switch.py
@@ -1,21 +1,39 @@
+from argparse import ArgumentTypeError
 from django.core.management.base import BaseCommand, CommandError
 
 from waffle.models import Switch
 
 
+def on_off_bool(string):
+    if string not in ['on', 'off']:
+        raise ArgumentTypeError("invalid choice: %r (choose from 'on', "
+                                "'off')" % string)
+    return string == 'on'
+
+
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument('positionals', nargs='*')
+        parser.add_argument(
+            'name',
+            nargs='?',
+            help='The name of the switch.')
+        parser.add_argument(
+            'state',
+            nargs='?',
+            type=on_off_bool,
+            help='The state of the switch: on or off.')
         parser.add_argument(
             '-l', '--list',
-            action='store_true', dest='list_switches', default=False,
-            help='List existing switches.'),
+            action='store_true',
+            dest='list_switches',
+            default=False,
+            help='List existing switches.')
         parser.add_argument(
             '--create',
             action='store_true',
             dest='create',
             default=False,
-            help="If the switch doesn't exist, create it."),
+            help='If the switch does not exist, create it.')
 
     help = 'Activate or deactivate a switch.'
 
@@ -29,29 +47,21 @@ class Command(BaseCommand):
             self.stdout.write('')
             return
 
-        switch_name = options['positionals'][0]
-        state = options['positionals'][1]
-        print(options['positionals'])
+        switch_name = options['name']
+        state = options['state']
 
-        if not (switch_name and state):
+        if not (switch_name and state is not None):
             raise CommandError('You need to specify a switch name and state.')
 
-        if state not in ['on', 'off']:
-            raise CommandError(
-                'You need to specify state of switch with "on" or "off".'
-            )
-
-        active = state == "on"
-        defaults = {'active': active}
-
         if options['create']:
-            switch, created = Switch.objects.get_or_create(name=switch_name,
-                                                           defaults=defaults)
+            switch, created = Switch.objects.get_or_create(name=switch_name)
             if created:
                 self.stdout.write('Creating switch: %s' % switch_name)
         else:
             try:
-                switch = Switch.objects.update_or_create(name=switch_name,
-                                                         defaults=defaults)
+                switch = Switch.objects.get(name=switch_name)
             except Switch.DoesNotExist:
-                raise CommandError("This switch doesn't exist.")
+                raise CommandError('This switch does not exist.')
+
+        switch.active = state
+        switch.save()


### PR DESCRIPTION
- Ensure that new switch is not created unless the --create flag is passed.
- Add tests to ensure no regression for the --create fix on all commands.
- Add separate positional arguments for commands (instead of "positionals") to improve the --help documentation.

-------

Managed to recover the lost commit that made me close #256 (thanks @jsocol for the help). Github doesn't allow re-opening PR after `git push --force` so I had to create a new PR.