### PR TITLE
Add search_fields to BaseAdmin.

### DIFF
--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -6,6 +6,8 @@ from waffle.models import Flag, Sample, Switch
 
 
 class BaseAdmin(admin.ModelAdmin):
+    search_fields = ('name', 'note')
+    
     def get_actions(self, request):
         actions = super(BaseAdmin, self).get_actions(request)
         if 'delete_selected' in actions:


### PR DESCRIPTION
With a lot of switches, flags or samples, it is easier to type the name you're looking for instead of scanning the list manually.