### PR TITLE
Updated User.is_authenticated usage to be compatible with Django 1.10+

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -204,7 +204,11 @@ class Flag(BaseModel):
         return group_ids
 
     def is_active_for_user(self, user):
-        authed = getattr(user, 'is_authenticated', lambda: False)()
+        # is_authenticated was a method in Django < 1.10
+        if callable(user.is_authenticated):
+            authed = user.is_authenticated()
+        else:
+            authed = user.is_authenticated
         if self.authenticated and authed:
             return True
 

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.models import User, AnonymousUser
+
+from waffle.models import Flag
+from waffle.tests.base import TestCase
+
+
+class FlagTests(TestCase):
+    def test_is_active_for_user(self):
+        flag = Flag.objects.create(name='foo', authenticated=True)
+        user = User.objects.create(username='foo')
+        assert flag.is_active_for_user(user)
+
+        user = AnonymousUser()
+        assert not flag.is_active_for_user(user)

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -161,7 +161,6 @@ class WaffleTests(TestCase):
         assert 'dwf_myflag' not in response.cookies
 
         request.user = User(username='foo')
-        assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
         self.assertEqual(b'on', response.content)
         assert 'dwf_myflag' not in response.cookies
@@ -177,7 +176,6 @@ class WaffleTests(TestCase):
         assert 'dwf_myflag' not in response.cookies
 
         request.user = User(username='foo')
-        assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
         self.assertEqual(b'on', response.content)
         assert 'dwf_myflag' not in response.cookies
@@ -194,7 +192,6 @@ class WaffleTests(TestCase):
         assert 'dwf_myflag' not in response.cookies
 
         request.user = User(username='foo')
-        assert request.user.is_authenticated()
         response = process_request(request, views.flag_in_view)
         self.assertEqual(b'off', response.content)
         assert 'dwf_myflag' not in response.cookies


### PR DESCRIPTION
User.is_authenticated is now a property in Django 1.10+ rather than a method. This change updates the usage to account for this change, while retaining backward compatibility with older versions of Django.