### PR TITLE
Feature: more granular querystring flag overrides

### DIFF
--- a/docs/starting/configuring.rst
+++ b/docs/starting/configuring.rst
@@ -40,8 +40,9 @@ behavior.
     Switches, and Samples from the DB configured for writes on cache misses.
 
 ``WAFFLE_OVERRIDE``
-    Allow *all* Flags to be controlled via the querystring (to allow
-    e.g. Selenium to control their behavior). Defaults to ``False``.
+    Allow Flags to be controlled via the querystring (to allow e.g. Selenium
+    to control their behavior), unless the given flag has explicitly set
+    ``allow_override``to ``False``. Defaults to ``False``.
 
 ``WAFFLE_SECURE``
     Whether to set the ``secure`` flag on cookies. Defaults to ``True``.

--- a/docs/testing/automated.rst
+++ b/docs/testing/automated.rst
@@ -57,6 +57,10 @@ Selenium_ or PhantomJS_) the ``WAFFLE_OVERRIDE`` :ref:`setting
 <starting-configuring>` makes it possible to control the value of any
 *Flag* via the querystring.
 
+It's also possible to have more granular control over which flags can
+be overridden by setting the ``allow_override`` attribute to ``True``
+on the chosen flag.
+
 .. highlight:: http
 
 For example, for a flag named ``foo``, we can ensure that it is "on" for

--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -7,7 +7,7 @@ from waffle.models import Flag, Sample, Switch
 
 class BaseAdmin(admin.ModelAdmin):
     search_fields = ('name', 'note')
-    
+
     def get_actions(self, request):
         actions = super(BaseAdmin, self).get_actions(request)
         if 'delete_selected' in actions:
@@ -43,8 +43,9 @@ delete_individually.short_description = 'Delete selected.'
 class FlagAdmin(BaseAdmin):
     actions = [enable_for_all, disable_for_all, delete_individually]
     list_display = ('name', 'note', 'everyone', 'percent', 'superusers',
-                    'staff', 'authenticated', 'languages')
-    list_filter = ('everyone', 'superusers', 'staff', 'authenticated')
+                    'staff', 'authenticated', 'languages', 'allow_override')
+    list_filter = ('everyone', 'superusers', 'staff',
+                   'authenticated', 'allow_override')
     raw_id_fields = ('users', 'groups')
     ordering = ('-id',)
 

--- a/waffle/migrations/0003_flag_allow_override.py
+++ b/waffle/migrations/0003_flag_allow_override.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('waffle', '0002_auto_20161201_0958'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='flag',
+            name='allow_override',
+            field=models.NullBooleanField(default=None),
+        ),
+    ]

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -157,6 +157,10 @@ class Flag(BaseModel):
     modified = models.DateTimeField(default=datetime.now, help_text=(
         'Date when this Flag was last modified.'))
 
+    allow_override = models.NullBooleanField(default=None, help_text=(
+        'Allow to control this flag via request\'s querystring '
+        '("Unknown" means following the global "WAFFLE_OVERRIDE" setting).'))
+
     objects = managers.FlagManager()
 
     SINGLE_CACHE_KEY = 'FLAG_CACHE_KEY'
@@ -240,8 +244,9 @@ class Flag(BaseModel):
         if not self.pk:
             return get_setting('FLAG_DEFAULT')
 
-        if get_setting('OVERRIDE'):
-            if self.name in request.GET:
+        if get_setting('OVERRIDE') or self.allow_override:
+            if (self.allow_override is not False and
+               self.name in request.GET):
                 return request.GET[self.name] == '1'
 
         if self.everyone:

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -240,6 +240,24 @@ class WaffleTests(TestCase):
         Flag.objects.create(name='foo')  # Off for everyone.
         assert waffle.flag_is_active(request, 'foo')
 
+    def test_override_enabled_on_flag(self):
+        request = get(foo='1')
+        # Off for everyone.
+        Flag.objects.create(name='foo', allow_override=True)
+        assert waffle.flag_is_active(request, 'foo')
+
+    @override_settings(WAFFLE_OVERRIDE=True)
+    def test_override_disabled_on_flag(self):
+        request = get(foo='1')
+        # Off for everyone.
+        Flag.objects.create(name='foo', allow_override=False)
+        assert not waffle.flag_is_active(request, 'foo')
+
+    def test_no_override(self):
+        request = get(foo='1')
+        Flag.objects.create(name='foo')  # Off for everyone.
+        assert not waffle.flag_is_active(request, 'foo')
+
     def test_testing_flag(self):
         Flag.objects.create(name='foo', testing=True)
         request = get(dwft_foo='1')


### PR DESCRIPTION
This enables the user to choose individual flags to be overridden in
the querystring. Currently we have a binary choice (all or none) via
`WAFFLE_OVERRIDE` setting.

Adds a new `NullBooleanField` field on the `Flag` model called
`allow_override`. The default value (`None`) means that the control
depends on the global `WAFFLE_OVERRIDE` value. When set to `False`
disables the override even if `WAFFLE_OVERRIDE` is set to `True`.
Finally, when the field is set to `True` we allow querystring
overrides for this flag (as described in documentation) even if
`WAFFLE_OVERRIDE` is set to `False`.