### PR TITLE
Management Command `waffle_flag` should set `everyone` option default to `None`

### DIFF
--- a/waffle/management/commands/waffle_flag.py
+++ b/waffle/management/commands/waffle_flag.py
@@ -78,6 +78,7 @@ class Command(BaseCommand):
             dest='create',
             default=False,
             help='If the flag doesn\'t exist, create it.')
+        parser.set_defaults(everyone=None)
 
     help = 'Modify a flag.'
 


### PR DESCRIPTION
Every time you run the `waffle_flag` command it will always set `everyone` to `False` and disable the feature flag even if you don't pass the `--deactivate` flag. Make sure the default `everyone` option is `None` so it doesn't affect individual flag runs such as `--groups`