### PR TITLE
Fix typo in command to run linter

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ export DJANGO_SETTINGS_MODULE="test_settings"
 usage() {
     echo "USAGE: $0 [command]"
     echo "  test - run the waffle tests"
-    echo "  link - run flake8"
+    echo "  lint - run flake8"
     echo "  shell - open the Django shell"
     echo "  makemigrations - create a schema migration"
     exit 1


### PR DESCRIPTION
In `run.sh`, the usage command describes the command to run the linter as `link`, but the switch/case block is looking for `lint`. This updates the usage function to print out the proper command to run the linter in the waffle-django project