### PR TITLE
Allow serializing/deserializing waffle models by natural key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ dist
 .pydevproject
 .settings
 .tox/
+.DS_Store
 docs/_*

--- a/waffle/managers.py
+++ b/waffle/managers.py
@@ -11,6 +11,9 @@ cache = get_cache()
 class BaseManager(models.Manager):
     KEY_SETTING = ''
 
+    def get_by_natural_key(self, name):
+        return self.get(name=name)
+
     def create(self, *args, **kwargs):
         ret = super(BaseManager, self).create(*args, **kwargs)
         cache_key = get_setting(self.KEY_SETTING)

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -31,6 +31,9 @@ class BaseModel(models.Model):
     def __str__(self):
         return self.name
 
+    def natural_key(self):
+        return (self.name,)
+
     @classmethod
     def _cache_key(cls, name):
         return keyfmt(get_setting(cls.SINGLE_CACHE_KEY), name)

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -1,0 +1,20 @@
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from waffle.models import Flag, Switch, Sample
+
+
+class ModelsTests(TestCase):
+    def test_natural_keys(self):
+        flag = Flag.objects.create(name='test-flag')
+        switch = Switch.objects.create(name='test-switch')
+        sample = Sample.objects.create(name='test-sample', percent=0)
+
+        self.assertEqual(flag.natural_key(), ('test-flag',))
+        self.assertEqual(switch.natural_key(), ('test-switch',))
+        self.assertEqual(sample.natural_key(), ('test-sample',))
+
+        self.assertEqual(Flag.objects.get_by_natural_key('test-flag'), flag)
+        self.assertEqual(Switch.objects.get_by_natural_key('test-switch'), switch)
+        self.assertEqual(Sample.objects.get_by_natural_key('test-sample'), sample)


### PR DESCRIPTION
We find it useful when building fixtures between environments to use natural keys to avoid collisions with incremental integer PKs. This patch adds support for dumping/loading waffle models by name.