### PR TITLE
Custom flag models

### DIFF
--- a/docs/starting/configuring.rst
+++ b/docs/starting/configuring.rst
@@ -11,6 +11,15 @@ behavior.
     The format for the cookies Waffle sets. Must contain ``%s``.
     Defaults to ``dwf_%s``.
 
+``WAFFLE_FLAG_MODEL``
+    The model that will be used to keep track of flags. Defaults to ``waffle.Flag``
+    which allows user- and group-based flags. Can be swapped for a different Flag model
+    that allows flagging based on other relationships or properties, such as an Organization 
+    a user belongs to.
+    Analogous functionality to Django's extendable User models.
+    Needs to be set at the start of a project. Migrations do not support changing after the
+    initial migration.
+
 ``WAFFLE_FLAG_DEFAULT``
     When a Flag is undefined in the database, Waffle considers it
     ``False``.  Set this to ``True`` to make Waffle consider undefined

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+from django.apps import apps as django_apps
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from waffle.utils import get_cache, get_setting, keyfmt
 
 VERSION = (0, 13, 0)
@@ -7,9 +10,7 @@ __version__ = '.'.join(map(str, VERSION))
 
 
 def flag_is_active(request, flag_name):
-    from .models import Flag
-
-    flag = Flag.get(flag_name)
+    flag = get_waffle_flag_model().get(flag_name)
     return flag.is_active(request)
 
 
@@ -25,3 +26,25 @@ def sample_is_active(sample_name):
 
     sample = Sample.get(sample_name)
     return sample.is_active()
+
+
+def get_waffle_flag_model():
+    """
+    Returns the waffle Flag model that is active in this project.
+    """
+    # Add backwards compatibility by not requiring adding of WAFFLE_FLAG_MODEL
+    # for everyone who upgrades
+    # At some point it would be helpful to require this to be defined explicitly, but no for now, to
+    # remove pain form upgrading.
+    flag_model = get_setting('FLAG_MODEL', 'waffle.Flag')
+
+    try:
+        return django_apps.get_model(flag_model)
+    except ValueError:
+        raise ImproperlyConfigured("WAFFLE_FLAG_MODEL must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise ImproperlyConfigured(
+            "WAFFLE_FLAG_MODEL refers to model '{}' that has not been installed".format(
+                settings.WAFFLE_FLAG_MODEL
+            )
+        )

--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -41,11 +41,14 @@ disable_for_all.short_description = _('Disable selected flags for everyone')
 delete_individually.short_description = _('Delete selected')
 
 
-class FlagAdmin(BaseAdmin):
+class AbstractFlagAdmin(BaseAdmin):
     actions = [enable_for_all, disable_for_all, delete_individually]
     list_display = ('name', 'note', 'everyone', 'percent', 'superusers',
                     'staff', 'authenticated', 'languages')
     list_filter = ('everyone', 'superusers', 'staff', 'authenticated')
+    ordering = ('-id',)
+
+class FlagAdmin(AbstractFlagAdmin):
     raw_id_fields = ('users', 'groups')
     ordering = ('-id',)
 

--- a/waffle/defaults.py
+++ b/waffle/defaults.py
@@ -16,6 +16,7 @@ SAMPLE_CACHE_KEY = 'sample:%s'
 ALL_SAMPLES_CACHE_KEY = 'samples:all'
 SWITCH_CACHE_KEY = 'switch:%s'
 ALL_SWITCHES_CACHE_KEY = 'switches:all'
+FLAG_MODEL = 'waffle.Flag'
 
 FLAG_DEFAULT = False
 SAMPLE_DEFAULT = False

--- a/waffle/locale/en_US/LC_MESSAGES/django.po
+++ b/waffle/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-21 09:17-0400\n"
+"POT-Creation-Date: 2018-04-24 15:31-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,190 +29,190 @@ msgstr ""
 msgid "Delete selected"
 msgstr ""
 
-#: admin.py:65
+#: admin.py:68
 msgid "Enable selected switches"
 msgstr ""
 
-#: admin.py:66
+#: admin.py:69
 msgid "Disable selected switches"
 msgstr ""
 
-#: models.py:120 models.py:343 models.py:394
+#: models.py:123 models.py:377 models.py:428
 msgid "The human/computer readable name."
 msgstr ""
 
-#: models.py:121 models.py:344 models.py:395
+#: models.py:124 models.py:378 models.py:429
 msgid "Name"
 msgstr ""
 
-#: models.py:126
+#: models.py:129
 msgid ""
 "Flip this flag on (Yes) or off (No) for everyone, overriding all other "
 "settings. Leave as Unknown to use normally."
 msgstr ""
 
-#: models.py:128
+#: models.py:131
 msgid "Everyone"
 msgstr ""
 
-#: models.py:135
+#: models.py:138
 msgid ""
 "A number between 0.0 and 99.9 to indicate a percentage of users for whom "
 "this flag will be active."
 msgstr ""
 
-#: models.py:137 models.py:402
+#: models.py:140 models.py:436
 msgid "Percent"
 msgstr ""
 
-#: models.py:141
+#: models.py:144
 msgid "Allow this flag to be set for a session for user testing"
 msgstr ""
 
-#: models.py:142
+#: models.py:145
 msgid "Testing"
 msgstr ""
 
-#: models.py:146
+#: models.py:149
 msgid "Flag always active for superusers?"
 msgstr ""
 
-#: models.py:147
+#: models.py:150
 msgid "Superusers"
 msgstr ""
 
-#: models.py:151
+#: models.py:154
 msgid "Flag always active for staff?"
 msgstr ""
 
-#: models.py:152
+#: models.py:155
 msgid "Staff"
 msgstr ""
 
-#: models.py:156
+#: models.py:159
 msgid "Flag always active for authenticated users?"
 msgstr ""
 
-#: models.py:157
+#: models.py:160
 msgid "Authenticated"
 msgstr ""
 
-#: models.py:162
+#: models.py:165
 msgid ""
 "Activate this flag for users with one of these languages (comma-separated "
 "list)"
 msgstr ""
 
-#: models.py:163
+#: models.py:166
 msgid "Languages"
 msgstr ""
 
-#: models.py:168
-msgid "Activate this flag for these user groups."
-msgstr ""
-
-#: models.py:169
-msgid "Groups"
-msgstr ""
-
-#: models.py:174
-msgid "Activate this flag for these users."
-msgstr ""
-
-#: models.py:175
-msgid "Users"
-msgstr ""
-
-#: models.py:179
+#: models.py:170
 msgid "Activate roll-out mode?"
 msgstr ""
 
-#: models.py:180
+#: models.py:171
 msgid "Rollout"
 msgstr ""
 
-#: models.py:184
+#: models.py:175
 msgid "Note where this Flag is used."
 msgstr ""
 
-#: models.py:185 models.py:354 models.py:407
+#: models.py:176 models.py:388 models.py:441
 msgid "Note"
 msgstr ""
 
-#: models.py:190
+#: models.py:181
 msgid "Date when this Flag was created."
 msgstr ""
 
-#: models.py:191 models.py:360 models.py:413
+#: models.py:182 models.py:394 models.py:447
 msgid "Created"
 msgstr ""
 
-#: models.py:195
+#: models.py:186
 msgid "Date when this Flag was last modified."
 msgstr ""
 
-#: models.py:196 models.py:365 models.py:418
+#: models.py:187 models.py:399 models.py:452
 msgid "Modified"
 msgstr ""
 
-#: models.py:205
+#: models.py:196
 msgid "Flag"
 msgstr ""
 
-#: models.py:206
+#: models.py:197
 msgid "Flags"
 msgstr ""
 
-#: models.py:348
+#: models.py:292
+msgid "Activate this flag for these user groups."
+msgstr ""
+
+#: models.py:293
+msgid "Groups"
+msgstr ""
+
+#: models.py:298
+msgid "Activate this flag for these users."
+msgstr ""
+
+#: models.py:299
+msgid "Users"
+msgstr ""
+
+#: models.py:382
 msgid "Is this switch active?"
 msgstr ""
 
-#: models.py:349
+#: models.py:383
 msgid "Active"
 msgstr ""
 
-#: models.py:353
+#: models.py:387
 msgid "Note where this Switch is used."
 msgstr ""
 
-#: models.py:359
+#: models.py:393
 msgid "Date when this Switch was created."
 msgstr ""
 
-#: models.py:364
+#: models.py:398
 msgid "Date when this Switch was last modified."
 msgstr ""
 
-#: models.py:374
+#: models.py:408
 msgid "Switch"
 msgstr ""
 
-#: models.py:375
+#: models.py:409
 msgid "Switches"
 msgstr ""
 
-#: models.py:400
+#: models.py:434
 msgid ""
 "A number between 0.0 and 100.0 to indicate a percentage of the time this "
 "sample will be active."
 msgstr ""
 
-#: models.py:406
+#: models.py:440
 msgid "Note where this Sample is used."
 msgstr ""
 
-#: models.py:412
+#: models.py:446
 msgid "Date when this Sample was created."
 msgstr ""
 
-#: models.py:417
+#: models.py:451
 msgid "Date when this Sample was last modified."
 msgstr ""
 
-#: models.py:427
+#: models.py:461
 msgid "Sample"
 msgstr ""
 
-#: models.py:428
+#: models.py:462
 msgid "Samples"
 msgstr ""

--- a/waffle/locale/ru/LC_MESSAGES/django.po
+++ b/waffle/locale/ru/LC_MESSAGES/django.po
@@ -8,15 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-21 09:13-0400\n"
+"POT-Creation-Date: 2018-04-24 15:31-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kostya Esmukov <kostya@esmukov.ru>, 2018\n"
-"Language-Team: Russian (https://www.transifex.com/django-waffle/teams/84077/ru/)\n"
+"Language-Team: Russian (https://www.transifex.com/django-waffle/teams/84077/"
+"ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #: admin.py:39
 msgid "Enable selected flags for everyone"
@@ -30,23 +33,23 @@ msgstr "Выключить выбранные Флаги для всех"
 msgid "Delete selected"
 msgstr "Удалить выбранные"
 
-#: admin.py:65
+#: admin.py:68
 msgid "Enable selected switches"
 msgstr "Включить выбранные Тумблеры"
 
-#: admin.py:66
+#: admin.py:69
 msgid "Disable selected switches"
 msgstr "Выключить выбранные Тумблеры"
 
-#: models.py:120 models.py:343 models.py:394
+#: models.py:123 models.py:377 models.py:428
 msgid "The human/computer readable name."
 msgstr "Человеко-/машиночитаемое имя"
 
-#: models.py:121 models.py:344 models.py:395
+#: models.py:124 models.py:378 models.py:429
 msgid "Name"
 msgstr "Имя"
 
-#: models.py:126
+#: models.py:129
 msgid ""
 "Flip this flag on (Yes) or off (No) for everyone, overriding all other "
 "settings. Leave as Unknown to use normally."
@@ -55,11 +58,11 @@ msgstr ""
 "настройки. Оставьте как Неизвестно, чтобы использовать обычный режим работы "
 "Флага."
 
-#: models.py:128
+#: models.py:131
 msgid "Everyone"
 msgstr "Переопределение для всех"
 
-#: models.py:135
+#: models.py:138
 msgid ""
 "A number between 0.0 and 99.9 to indicate a percentage of users for whom "
 "this flag will be active."
@@ -67,43 +70,43 @@ msgstr ""
 "Число в интервале от 0.0 до 99.9, указывающее процент пользователей, для "
 "которых этот Флаг будет активен."
 
-#: models.py:137 models.py:402
+#: models.py:140 models.py:436
 msgid "Percent"
 msgstr "Процент"
 
-#: models.py:141
+#: models.py:144
 msgid "Allow this flag to be set for a session for user testing"
 msgstr "Разрешить включение этого Флага со стороны пользователя"
 
-#: models.py:142
+#: models.py:145
 msgid "Testing"
 msgstr "Режим тестирования"
 
-#: models.py:146
+#: models.py:149
 msgid "Flag always active for superusers?"
 msgstr "Флаг всегда активен для суперпользователей?"
 
-#: models.py:147
+#: models.py:150
 msgid "Superusers"
 msgstr "Суперпользователи"
 
-#: models.py:151
+#: models.py:154
 msgid "Flag always active for staff?"
 msgstr "Флаг всегда активен для персонала?"
 
-#: models.py:152
+#: models.py:155
 msgid "Staff"
 msgstr "Персонал"
 
-#: models.py:156
+#: models.py:159
 msgid "Flag always active for authenticated users?"
 msgstr "Флаг всегда активен для аутентифицированных пользователей?"
 
-#: models.py:157
+#: models.py:160
 msgid "Authenticated"
 msgstr "Аутентифицированные пользователи"
 
-#: models.py:162
+#: models.py:165
 msgid ""
 "Activate this flag for users with one of these languages (comma-separated "
 "list)"
@@ -111,95 +114,95 @@ msgstr ""
 "Включить этот Флаг для пользователей с одним из перечисленных (через "
 "запятую) языков"
 
-#: models.py:163
+#: models.py:166
 msgid "Languages"
 msgstr "Языки"
 
-#: models.py:168
-msgid "Activate this flag for these user groups."
-msgstr "Включить этот Флаг для этих пользовательских групп."
-
-#: models.py:169
-msgid "Groups"
-msgstr "Группы"
-
-#: models.py:174
-msgid "Activate this flag for these users."
-msgstr "Включить этот Флаг для этих пользователей."
-
-#: models.py:175
-msgid "Users"
-msgstr "Пользователи"
-
-#: models.py:179
+#: models.py:170
 msgid "Activate roll-out mode?"
 msgstr "Активировать режим выкатки?"
 
-#: models.py:180
+#: models.py:171
 msgid "Rollout"
 msgstr "Режим выкатки"
 
-#: models.py:184
+#: models.py:175
 msgid "Note where this Flag is used."
 msgstr "Примечание о том, где используется этот Флаг."
 
-#: models.py:185 models.py:354 models.py:407
+#: models.py:176 models.py:388 models.py:441
 msgid "Note"
 msgstr "Примечание"
 
-#: models.py:190
+#: models.py:181
 msgid "Date when this Flag was created."
 msgstr "Дата создания этого Флага."
 
-#: models.py:191 models.py:360 models.py:413
+#: models.py:182 models.py:394 models.py:447
 msgid "Created"
 msgstr "Создан"
 
-#: models.py:195
+#: models.py:186
 msgid "Date when this Flag was last modified."
 msgstr "Дата последнего изменения этого Флага."
 
-#: models.py:196 models.py:365 models.py:418
+#: models.py:187 models.py:399 models.py:452
 msgid "Modified"
 msgstr "Изменён"
 
-#: models.py:205
+#: models.py:196
 msgid "Flag"
 msgstr "Флаг"
 
-#: models.py:206
+#: models.py:197
 msgid "Flags"
 msgstr "Флаги"
 
-#: models.py:348
+#: models.py:292
+msgid "Activate this flag for these user groups."
+msgstr "Включить этот Флаг для этих пользовательских групп."
+
+#: models.py:293
+msgid "Groups"
+msgstr "Группы"
+
+#: models.py:298
+msgid "Activate this flag for these users."
+msgstr "Включить этот Флаг для этих пользователей."
+
+#: models.py:299
+msgid "Users"
+msgstr "Пользователи"
+
+#: models.py:382
 msgid "Is this switch active?"
 msgstr "Тумблер включен?"
 
-#: models.py:349
+#: models.py:383
 msgid "Active"
 msgstr "Включён"
 
-#: models.py:353
+#: models.py:387
 msgid "Note where this Switch is used."
 msgstr "Примечание о том, где используется этот Тумблер."
 
-#: models.py:359
+#: models.py:393
 msgid "Date when this Switch was created."
 msgstr "Дата создания этого Тумблера."
 
-#: models.py:364
+#: models.py:398
 msgid "Date when this Switch was last modified."
 msgstr "Дата последнего изменения этого Тумблера."
 
-#: models.py:374
+#: models.py:408
 msgid "Switch"
 msgstr "Тумблер"
 
-#: models.py:375
+#: models.py:409
 msgid "Switches"
 msgstr "Тумблеры"
 
-#: models.py:400
+#: models.py:434
 msgid ""
 "A number between 0.0 and 100.0 to indicate a percentage of the time this "
 "sample will be active."
@@ -207,22 +210,22 @@ msgstr ""
 "Число в интервале от 0.0 до 100.0, указывающее процент проверок, в который "
 "эта Проба будет активной."
 
-#: models.py:406
+#: models.py:440
 msgid "Note where this Sample is used."
 msgstr "Примечание о том, где используется эта Проба."
 
-#: models.py:412
+#: models.py:446
 msgid "Date when this Sample was created."
 msgstr "Дата создания этой Пробы."
 
-#: models.py:417
+#: models.py:451
 msgid "Date when this Sample was last modified."
 msgstr "Дата последнего изменения этой Пробы."
 
-#: models.py:427
+#: models.py:461
 msgid "Sample"
 msgstr "Проба"
 
-#: models.py:428
+#: models.py:462
 msgid "Samples"
 msgstr "Пробы"

--- a/waffle/management/commands/waffle_flag.py
+++ b/waffle/management/commands/waffle_flag.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand, CommandError
 
-from waffle.models import Flag
+from waffle import get_waffle_flag_model
 
 
 class Command(BaseCommand):
@@ -82,8 +82,11 @@ class Command(BaseCommand):
 
     help = 'Modify a flag.'
 
-    def handle(self, *args, **options):
-        if options['list_flags']:
+    def handle(self, flag_name=None, *args, **options):
+        Flag = get_waffle_flag_model()
+        list_flags = options.get('list_flags', False)
+
+        if list_flags:
             self.stdout.write('Flags:')
             for flag in Flag.objects.iterator():
                 self.stdout.write('NAME: %s' % flag.name)

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -111,13 +111,12 @@ def set_flag(request, flag_name, active=True, session_only=False):
     request.waffles[flag_name] = [active, session_only]
 
 
-class Flag(BaseModel):
+class AbstractBaseFlag(BaseModel):
     """A feature flag.
 
     Flags are active (or not) on a per-request basis.
 
     """
-
     name = models.CharField(
         max_length=100,
         unique=True,
@@ -166,18 +165,6 @@ class Flag(BaseModel):
         help_text=_('Activate this flag for users with one of these languages (comma-separated list)'),
         verbose_name=_('Languages'),
     )
-    groups = models.ManyToManyField(
-        Group,
-        blank=True,
-        help_text=_('Activate this flag for these user groups.'),
-        verbose_name=_('Groups'),
-    )
-    users = models.ManyToManyField(
-        settings.AUTH_USER_MODEL,
-        blank=True,
-        help_text=_('Activate this flag for these users.'),
-        verbose_name=_('Users'),
-    )
     rollout = models.BooleanField(
         default=False,
         help_text=_('Activate roll-out mode?'),
@@ -208,47 +195,17 @@ class Flag(BaseModel):
     class Meta:
         verbose_name = _('Flag')
         verbose_name_plural = _('Flags')
+        abstract = True
 
     def flush(self):
-        keys = [
-            self._cache_key(self.name),
-            keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), self.name),
-            keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), self.name),
-            get_setting('ALL_FLAGS_CACHE_KEY'),
-        ]
+        keys = self.get_flush_keys()
         cache.delete_many(keys)
 
-    def _get_user_ids(self):
-        cache_key = keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), self.name)
-        cached = cache.get(cache_key)
-        if cached == CACHE_EMPTY:
-            return set()
-        if cached:
-            return cached
-
-        user_ids = set(self.users.all().values_list('pk', flat=True))
-        if not user_ids:
-            cache.add(cache_key, CACHE_EMPTY)
-            return set()
-
-        cache.add(cache_key, user_ids)
-        return user_ids
-
-    def _get_group_ids(self):
-        cache_key = keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), self.name)
-        cached = cache.get(cache_key)
-        if cached == CACHE_EMPTY:
-            return set()
-        if cached:
-            return cached
-
-        group_ids = set(self.groups.all().values_list('pk', flat=True))
-        if not group_ids:
-            cache.add(cache_key, CACHE_EMPTY)
-            return set()
-
-        cache.add(cache_key, group_ids)
-        return group_ids
+    def get_flush_keys(self):
+        return [
+            self._cache_key(self.name),
+            get_setting('ALL_FLAGS_CACHE_KEY'),
+        ]
 
     def is_active_for_user(self, user):
         if self.authenticated and user.is_authenticated:
@@ -260,15 +217,6 @@ class Flag(BaseModel):
         if self.superusers and getattr(user, 'is_superuser', False):
             return True
 
-        user_ids = self._get_user_ids()
-        if hasattr(user, 'pk') and user.pk in user_ids:
-            return True
-
-        if hasattr(user, 'groups'):
-            group_ids = self._get_group_ids()
-            user_groups = set(user.groups.all().values_list('pk', flat=True))
-            if group_ids.intersection(user_groups):
-                return True
         return None
 
     def _is_active_for_user(self, request):
@@ -332,6 +280,88 @@ class Flag(BaseModel):
             set_flag(request, self.name, False, self.rollout)
 
         return False
+
+
+class AbstractUserFlag(AbstractBaseFlag):
+    FLAG_USERS_CACHE_KEY = 'FLAG_USERS_CACHE_KEY'
+    FLAG_GROUPS_CACHE_KEY = 'FLAG_GROUPS_CACHE_KEY'
+
+    groups = models.ManyToManyField(
+        Group,
+        blank=True,
+        help_text=_('Activate this flag for these user groups.'),
+        verbose_name=_('Groups'),
+    )
+    users = models.ManyToManyField(
+        settings.AUTH_USER_MODEL,
+        blank=True,
+        help_text=_('Activate this flag for these users.'),
+        verbose_name=_('Users'),
+    )
+
+    class Meta(AbstractBaseFlag.Meta):
+        abstract = True
+
+    def get_flush_keys(self):
+        flush_keys = super(AbstractUserFlag, self).get_flush_keys()
+        flush_keys.extend([
+            keyfmt(get_setting(Flag.FLAG_USERS_CACHE_KEY), self.name),
+            keyfmt(get_setting(Flag.FLAG_GROUPS_CACHE_KEY), self.name),
+        ])
+        return flush_keys
+
+    def is_active_for_user(self, user):
+        is_active = super(AbstractUserFlag, self).is_active_for_user(user)
+        if is_active:
+            return is_active
+
+        user_ids = self._get_user_ids()
+        if hasattr(user, 'pk') and user.pk in user_ids:
+            return True
+
+        if hasattr(user, 'groups'):
+            group_ids = self._get_group_ids()
+            user_groups = set(user.groups.all().values_list('pk', flat=True))
+            if group_ids.intersection(user_groups):
+                return True
+        return None
+
+    def _get_user_ids(self):
+        cache_key = keyfmt(get_setting(Flag.FLAG_USERS_CACHE_KEY), self.name)
+        cached = cache.get(cache_key)
+        if cached == CACHE_EMPTY:
+            return set()
+        if cached:
+            return cached
+
+        user_ids = set(self.users.all().values_list('pk', flat=True))
+        if not user_ids:
+            cache.add(cache_key, CACHE_EMPTY)
+            return set()
+
+        cache.add(cache_key, user_ids)
+        return user_ids
+
+    def _get_group_ids(self):
+        cache_key = keyfmt(get_setting(Flag.FLAG_GROUPS_CACHE_KEY), self.name)
+        cached = cache.get(cache_key)
+        if cached == CACHE_EMPTY:
+            return set()
+        if cached:
+            return cached
+
+        group_ids = set(self.groups.all().values_list('pk', flat=True))
+        if not group_ids:
+            cache.add(cache_key, CACHE_EMPTY)
+            return set()
+
+        cache.add(cache_key, group_ids)
+        return group_ids
+
+
+class Flag(AbstractUserFlag):
+    class Meta(AbstractUserFlag.Meta):
+        swappable = 'WAFFLE_FLAG_MODEL'
 
 
 class Switch(BaseModel):
@@ -435,3 +465,4 @@ class Sample(BaseModel):
         if not self.pk:
             return get_setting('SAMPLE_DEFAULT')
         return Decimal(str(random.uniform(0, 100))) <= self.percent
+

--- a/waffle/tests/test_decorators.py
+++ b/waffle/tests/test_decorators.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 
-from waffle.models import Flag, Switch
+from waffle import get_waffle_flag_model
+from waffle.models import Switch
 from waffle.tests.base import TestCase
+
+Flag = get_waffle_flag_model()
 
 
 class DecoratorTests(TestCase):

--- a/waffle/tests/test_management.py
+++ b/waffle/tests/test_management.py
@@ -4,8 +4,11 @@ import six
 from django.core.management import call_command, CommandError
 from django.contrib.auth.models import Group
 
-from waffle.models import Flag, Sample, Switch
+from waffle import get_waffle_flag_model
+from waffle.models import Sample, Switch
 from waffle.tests.base import TestCase
+
+Flag = get_waffle_flag_model()
 
 
 class WaffleFlagManagementCommandTests(TestCase):

--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -6,8 +6,11 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase, RequestFactory
 
 import waffle
-from waffle.models import Switch, Flag, Sample
+from waffle import get_waffle_flag_model
+from waffle.models import Switch, Sample
 from waffle.testutils import override_switch, override_flag, override_sample
+
+Flag = get_waffle_flag_model()
 
 
 class OverrideSwitchTests(TestCase):

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -2,8 +2,11 @@ from __future__ import unicode_literals
 
 from django.urls import reverse
 
-from waffle.models import Flag, Sample, Switch
+from waffle import get_waffle_flag_model
+from waffle.models import Sample, Switch
 from waffle.tests.base import TestCase
+
+Flag = get_waffle_flag_model()
 
 
 class WaffleViewTests(TestCase):

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -11,9 +11,12 @@ import mock
 
 import waffle
 from test_app import views
+from waffle import get_waffle_flag_model
 from waffle.middleware import WaffleMiddleware
-from waffle.models import Flag, Sample, Switch
+from waffle.models import Sample, Switch
 from waffle.tests.base import TestCase
+
+Flag = get_waffle_flag_model()
 
 
 def get(**kw):

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -4,7 +4,8 @@ import sys
 import types
 from functools import wraps
 
-from waffle.models import Flag, Switch, Sample
+from waffle.models import Switch, Sample
+from waffle import get_waffle_flag_model
 
 
 __all__ = ['override_flag', 'override_sample', 'override_switch']
@@ -108,7 +109,7 @@ class override_switch(_overrider):
 
 
 class override_flag(_overrider):
-    cls = Flag
+    cls = get_waffle_flag_model()
 
     def update(self, active):
         obj = self.cls.objects.get(pk=self.obj.pk)

--- a/waffle/utils.py
+++ b/waffle/utils.py
@@ -10,11 +10,20 @@ import waffle
 from waffle import defaults
 
 
-def get_setting(name):
+def get_setting(name, more_defaults=None):
+    """
+    :param name: Name of WAFFLE_* setting (value of *) to get from settings or waffle.defaults
+    :param more_defaults: additional app-defined defaults
+    :return: the setting value
+    """
     try:
         return getattr(settings, 'WAFFLE_' + name)
     except AttributeError:
-        return getattr(defaults, name)
+        try:
+            return getattr(defaults, name)
+        except AttributeError:
+            more_defaults = more_defaults or {}
+            return more_defaults[name]
 
 
 def keyfmt(k, v=None):

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -4,8 +4,8 @@ from django.http import HttpResponse
 from django.template import loader
 from django.views.decorators.cache import never_cache
 
-from waffle import flag_is_active, sample_is_active
-from waffle.models import Flag, Sample, Switch
+from waffle import flag_is_active, sample_is_active, get_waffle_flag_model
+from waffle.models import Sample, Switch
 from waffle.utils import get_setting, keyfmt, get_cache
 
 
@@ -19,7 +19,7 @@ def wafflejs(request):
 
 
 def _generate_waffle_js(request):
-    flags = Flag.get_all()
+    flags = get_waffle_flag_model().get_all()
     flag_values = [(f.name, f.is_active(request)) for f in flags]
 
     switches = Switch.get_all()


### PR DESCRIPTION
**WAFFLE_FLAG_MODEL**

The model that will be used to keep track of flags. Defaults to `waffle.Flag` which allows user- and group-based flags. Can be swapped for a different Flag model that allows flagging based on other relationships or properties, such as an Organization a user belongs to. Analogous functionality to Django's extendable User models. Needs to be set at the start of a project. 

`Obs.:` Migrations do not support changing after the initial migration.


This PR creates two abstract models to help users create their own Flag model with existing functionality:  `AbstractBaseFlag` and `AbstractUserFlag`.

This is the same code written by @koliber [here](https://github.com/jsocol/django-waffle/pull/243), I only rebased it.

fixes #181, fixes #286 