### PR TITLE
Waffle flag switch calls

### DIFF
--- a/docs/usage/helpers.rst
+++ b/docs/usage/helpers.rst
@@ -1,0 +1,76 @@
+.. _helpers:
+
+=============================
+Helpers for flags based logic
+=============================
+
+Django Waffle provide some helpers and decorators to make easy to adapt
+your logic to be based on flags/switches status, and also make easy to 
+remove these flags/switched from code after the feature is accepted or
+rejected.   
+
+
+Waffle callables
+================
+
+The best way to make a feature flip is by modularizing your code, so
+the active and inactive states logic don't get mixed. This way is 
+easier to read the code and to remove the feature flag/switch after.
+
+Django Waffle provides a ``@waffle_callable`` decorator to mark
+functions to be called or not by the helpers depending on the 
+flag/switch state at the moment.
+
+Eg.::
+    
+    from waffle.decorators import waffle_callable
+
+    @waffle_callable
+    def my_great_function(a, b, c):
+        return [a, b, c]
+
+
+Flags
+=====
+
+There is a ``waffle_flag_call()`` helper to branch logic depending on 
+flag state. It receives the request, the flag name, the active state
+waffle_callable and the inactive waffle_callable (optional).
+
+It checks whether the flag is active and calls the proper 
+``waffle_callable``::
+
+    waffle_flag_call(
+        request, 'my-flag', my_great_function(1, 2, 3), 
+        my_inactve_function())
+
+If you want to check if the feature is inactive to run your 
+waffle_callable, you can add an exclamation point before your flag 
+name::
+
+    from waffle import waffle_flag_call
+
+    waffle_flag_call(
+        request, '!my-flag', my_inactve_function())
+
+Switches
+========
+
+The logic is the same as for flags. There's a ``waffle_switch_call()``
+helper to branch logic depending on the flag  state. It receives the 
+the flag name, the active state waffle_callable and the inactive 
+waffle_callable (optional).
+
+It checks whether the flag is active and calls the proper 
+``waffle_callable``::
+
+    from waffle import waffle_switch_call
+
+    waffle_switch_call(
+        'my-switch', my_great_function(1, 2, 3), my_inactve_function())
+
+If you want to check if the feature is inactive to run your 
+waffle_callable, you can add an exclamation point before your switch 
+name::
+
+    waffle_switch_call('!my-switch', my_inactve_function())

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -14,6 +14,7 @@ JavaScript.
    
    views
    decorators
+   helpers
    templates
    javascript
    cli

--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from waffle.utils import get_cache, get_setting, keyfmt
+from waffle.helpers import waffle_flag_call, waffle_switch_call
 
 VERSION = (0, 13, 0)
 __version__ = '.'.join(map(str, VERSION))

--- a/waffle/callables.py
+++ b/waffle/callables.py
@@ -1,0 +1,9 @@
+class WaffleCallable(object):
+
+    def __init__(self, func, args=[], kwargs={}):
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def __call__(self):
+        return self.func(*self.args, **self.kwargs)

--- a/waffle/decorators.py
+++ b/waffle/decorators.py
@@ -8,6 +8,7 @@ from django.urls import reverse, NoReverseMatch
 from django.utils.decorators import available_attrs
 
 from waffle import flag_is_active, switch_is_active
+from waffle.callables import WaffleCallable
 
 
 def waffle_flag(flag_name, redirect_to=None):
@@ -57,3 +58,9 @@ def get_response_to_redirect(view, *args, **kwargs):
         return redirect(reverse(view, args=args, kwargs=kwargs)) if view else None
     except NoReverseMatch:
         return None
+
+
+def waffle_callable(func):
+    def _wrapped_function(*args, **kwargs):
+        return WaffleCallable(func, args=args, kwargs=kwargs)
+    return _wrapped_function

--- a/waffle/helpers.py
+++ b/waffle/helpers.py
@@ -1,0 +1,61 @@
+from waffle.callables import WaffleCallable
+
+
+def waffle_flag_call(
+        request, flag_name, active_callable, inactive_callable=None):
+    from waffle import flag_is_active
+    
+    assert (
+        type(active_callable) == WaffleCallable
+    ), (
+        'Passing a `active_callable` argument to `waffle_flag_call` is '
+        'required and has to be a `WaffleCallable`'
+    )
+
+    assert (
+        inactive_callable is None or type(inactive_callable) == WaffleCallable
+    ), (
+        'Passing a `inactive_callable` argument to `waffle_flag_call` is not '
+        'required but if present it has to be a `WaffleCallable`'
+    )
+
+    if flag_name.startswith('!'):
+        active = not flag_is_active(request, flag_name[1:])
+    else:
+        active = flag_is_active(request, flag_name)
+
+    if active:
+        return active_callable()
+
+    if inactive_callable:
+        return inactive_callable()
+
+
+def waffle_switch_call(
+        switch_name, active_callable, inactive_callable=None):
+    from waffle import switch_is_active
+    
+    assert (
+        type(active_callable) == WaffleCallable
+    ), (
+        'Passing a `active_callable` argument to `waffle_switch_call` is '
+        'required and has to be a `WaffleCallable`'
+    )
+
+    assert (
+        inactive_callable is None or type(inactive_callable) == WaffleCallable
+    ), (
+        'Passing a `inactive_callable` argument to `waffle_switch_call` is not '
+        'required but if present it has to be a `WaffleCallable`'
+    )
+
+    if switch_name.startswith('!'):
+        active = not switch_is_active(switch_name[1:])
+    else:
+        active = switch_is_active(switch_name)
+
+    if active:
+        return active_callable()
+
+    if inactive_callable:
+        return inactive_callable()

--- a/waffle/tests/test_decorators.py
+++ b/waffle/tests/test_decorators.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 from waffle.models import Flag, Switch
 from waffle.tests.base import TestCase
+from waffle.decorators import waffle_callable
+from waffle.callables import WaffleCallable
 
 
 class DecoratorTests(TestCase):
@@ -102,3 +104,13 @@ class DecoratorTests(TestCase):
         Flag.objects.create(name='foo', everyone=True)
         resp = self.client.get('/flagged_view_with_invalid_redirect')
         self.assertEqual(200, resp.status_code)
+
+    def test_waffle_callable_decorated_function_only_called_if_called_twice(self):
+
+        @waffle_callable
+        def test_func(a, b, c):
+            return (1, 2, 3)
+
+        test_func_callable = test_func('a', 'b', 'c')
+        self.assertEqual(type(test_func_callable), WaffleCallable)
+        self.assertEqual(test_func_callable(), (1, 2, 3))

--- a/waffle/tests/test_helpers.py
+++ b/waffle/tests/test_helpers.py
@@ -1,0 +1,136 @@
+from __future__ import unicode_literals
+
+import mock
+from django.test import RequestFactory
+from waffle.tests.base import TestCase
+from waffle import waffle_flag_call, waffle_switch_call
+from waffle.callables import WaffleCallable
+
+
+class WaffleFlagCallTests(TestCase):
+
+    def setUp(self):
+        self.active_callable = WaffleCallable(mock.MagicMock())
+        self.inactive_callable = WaffleCallable(mock.MagicMock())
+        factory = RequestFactory()
+        self.request = factory.get('/any/url')
+
+    @mock.patch('waffle.flag_is_active', return_value=True)
+    def test_waffle_flag_call_calls_active_callable_if_flag_active_without_exclamation(
+            self, flag_is_active):
+            
+        waffle_flag_call(
+            self.request, 'fake_flag', self.active_callable, 
+            self.inactive_callable)
+
+        flag_is_active.assert_called_once_with(self.request, 'fake_flag')
+        self.active_callable.func.assert_called_once_with()
+        self.inactive_callable.func.assert_not_called()
+
+    @mock.patch('waffle.flag_is_active', return_value=False)
+    def test_waffle_flag_call_calls_inactive_callable_if_flag_inactive_without_exclamation(
+            self, flag_is_active):
+            
+        waffle_flag_call(
+            self.request, 'fake_flag', self.active_callable, 
+            self.inactive_callable)
+
+        flag_is_active.assert_called_once_with(self.request, 'fake_flag')
+        self.active_callable.func.assert_not_called()
+        self.inactive_callable.func.assert_called_once_with()
+        
+    @mock.patch('waffle.flag_is_active', return_value=True)
+    def test_waffle_flag_call_calls_active_callable_if_flag_active_with_exclamation(
+            self, flag_is_active):
+        waffle_flag_call(
+            self.request, '!fake_flag', self.active_callable, 
+            self.inactive_callable)
+
+        flag_is_active.assert_called_once_with(self.request, 'fake_flag')
+        self.active_callable.func.assert_not_called()
+        self.inactive_callable.func.assert_called_once_with()
+
+    @mock.patch('waffle.flag_is_active', return_value=False)
+    def test_waffle_flag_call_calls_active_callable_if_flag_inactive_with_exclamation(
+            self, flag_is_active):
+        waffle_flag_call(
+            self.request, '!fake_flag', self.active_callable, 
+            self.inactive_callable)
+
+        flag_is_active.assert_called_once_with(self.request, 'fake_flag')
+        self.active_callable.func.assert_called_once_with()
+        self.inactive_callable.func.assert_not_called()
+        
+    def test_call_waffle_flag_call_with_not_WaffleCallable_active_callable(self):
+        with self.assertRaises(AssertionError):
+            waffle_flag_call(
+                self.request, '!fake_flag', None,
+                self.inactive_callable)
+
+    def test_call_waffle_flag_call_with_not_none_or_WaffleCallable_inactive_callable(self):
+        with self.assertRaises(AssertionError):
+            waffle_flag_call(
+                self.request, '!fake_flag', self.active_callable,
+                'test')
+
+
+class WaffleSwitchCallTests(TestCase):
+
+    def setUp(self):
+        self.active_callable = WaffleCallable(mock.MagicMock())
+        self.inactive_callable = WaffleCallable(mock.MagicMock())
+        factory = RequestFactory()
+        self.request = factory.get('/any/url')
+
+    @mock.patch('waffle.switch_is_active', return_value=True)
+    def test_waffle_switch_call_calls_active_callable_if_switch_active_without_exclamation(
+            self, switch_is_active):
+            
+        waffle_switch_call(
+            'fake_switch', self.active_callable, self.inactive_callable)
+
+        switch_is_active.assert_called_once_with('fake_switch')
+        self.active_callable.func.assert_called_once_with()
+        self.inactive_callable.func.assert_not_called()
+
+    @mock.patch('waffle.switch_is_active', return_value=False)
+    def test_waffle_switch_call_calls_inactive_callable_if_switch_inactive_without_exclamation(
+            self, switch_is_active):
+            
+        waffle_switch_call(
+            'fake_switch', self.active_callable, self.inactive_callable)
+
+        switch_is_active.assert_called_once_with('fake_switch')
+        self.active_callable.func.assert_not_called()
+        self.inactive_callable.func.assert_called_once_with()
+        
+    @mock.patch('waffle.switch_is_active', return_value=True)
+    def test_waffle_switch_call_calls_active_callable_if_switch_active_with_exclamation(
+            self, switch_is_active):
+        waffle_switch_call(
+            '!fake_switch', self.active_callable, self.inactive_callable)
+
+        switch_is_active.assert_called_once_with('fake_switch')
+        self.active_callable.func.assert_not_called()
+        self.inactive_callable.func.assert_called_once_with()
+
+    @mock.patch('waffle.switch_is_active', return_value=False)
+    def test_waffle_switch_call_calls_active_callable_if_switch_inactive_with_exclamation(
+            self, switch_is_active):
+        waffle_switch_call(
+            '!fake_switch', self.active_callable, 
+            self.inactive_callable)
+
+        switch_is_active.assert_called_once_with('fake_switch')
+        self.active_callable.func.assert_called_once_with()
+        self.inactive_callable.func.assert_not_called()
+        
+    def test_call_waffle_switch_call_with_not_WaffleCallable_active_callable(self):
+        with self.assertRaises(AssertionError):
+            waffle_switch_call(
+                '!fake_switch', None, self.inactive_callable)
+
+    def test_call_waffle_switch_call_with_not_none_or_WaffleCallable_inactive_callable(self):
+        with self.assertRaises(AssertionError):
+            waffle_switch_call(
+                '!fake_switch', self.active_callable, 'test')


### PR DESCRIPTION
Creates a way to avoid nesting code with if/else when changing logic whether flag is active or not. This force the users of the lib of creating more readable and modular code.

It also makes easier to implement automatic removal of flags in  code base using Abstract Syntax Tree tools like astroid.

In this PR users now have a decorator `@waffle_callable` for marking functions as they are only running based on a flag/switch state. And two helpers: one for flag `waffle_flag_call()` and `waffle_switch_call()` where the user pass the WaffleCallables and the required parameter to check the flag/switch state (request and flag name for flags and switch name for switches).

fixes #288 
