### PR TITLE
Add support for running tests with Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,24 @@ python:
   - "3.6"
 
 matrix:
- include:
-  - python: 3.6
-    env: TOXENV=i18n
+  include:
+    - python: 3.6
+      env: TOXENV=i18n
 
 install:
- - pip install tox tox-travis
+  - pip install tox tox-travis
+
+# Some tests may require accessing the database from multiple threads
+# (see #296), which isn't supported by the sqlite3 engine. Run the tests with
+# Postgres in CI to allow full test coverage.
+services:
+  postgresql
+
+before_script:
+  - psql -c 'create database waffle_test;' -U postgres
+
+env:
+  - DATABASE_URL=postgres://postgres@localhost:5432/waffle_test
 
 script:
- - tox
+  - tox

--- a/test_settings.py
+++ b/test_settings.py
@@ -28,6 +28,16 @@ DATABASES = {
     }
 }
 
+if 'DATABASE_URL' in os.environ:
+    try:
+        import dj_database_url
+        import psycopg2
+        DATABASES['default'] = dj_database_url.config()
+    except ImportError:
+        raise ImportError('Using the DATABASE_URL variable requires '
+                          'dj-database-url and psycopg2. Try:\n\npip install '
+                          '-r travis.txt')
+
 INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     -rtravis.txt
+passenv = DATABASE_URL
 commands =
     ./run.sh test
 

--- a/travis.txt
+++ b/travis.txt
@@ -2,6 +2,8 @@
 # versions.
 mock==1.3.0
 Jinja2>=2.7.1
+dj-database-url==0.5.0
 django-jinja>=2.1,<3
+psycopg2>=2.7.5
 
 transifex-client


### PR DESCRIPTION
This adds support for setting the DATABASE_URL environment variable to run tests with database engines other than sqlite3 locally. It also configures the CI build to run the tests with Postgres.