### PR TITLE
Ensuring that the testutils overriders flush the object caches when setting or restoring switch/flag/sample state.  Fixes #309.

### DIFF
--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from decimal import Decimal
 
 from django.contrib.auth.models import AnonymousUser
+from django.db import transaction
 from django.test import TransactionTestCase, RequestFactory
 
 import waffle
@@ -87,6 +88,18 @@ class OverrideSwitchTests(TransactionTestCase):
 
         assert Switch.objects.get(name='foo').active
 
+    def test_cache_is_flushed_by_testutils_even_in_transaction(self):
+        Switch.objects.create(name='foo', active=True)
+
+        with transaction.atomic():
+            with override_switch('foo', active=True):
+                assert waffle.switch_is_active('foo')
+
+            with override_switch('foo', active=False):
+                assert not waffle.switch_is_active('foo')
+
+        assert waffle.switch_is_active('foo')
+
 
 def req():
     r = RequestFactory().get('/')
@@ -139,6 +152,18 @@ class OverrideFlagTests(TransactionTestCase):
 
         assert not waffle.get_waffle_flag_model().objects.filter(name='foo').exists()
 
+    def test_cache_is_flushed_by_testutils_even_in_transaction(self):
+        waffle.get_waffle_flag_model().objects.create(name='foo', everyone=True)
+
+        with transaction.atomic():
+            with override_flag('foo', active=True):
+                assert waffle.flag_is_active(req(), 'foo')
+
+            with override_flag('foo', active=False):
+                assert not waffle.flag_is_active(req(), 'foo')
+
+        assert waffle.flag_is_active(req(), 'foo')
+
 
 class OverrideSampleTests(TransactionTestCase):
     def test_sample_existed_and_was_100(self):
@@ -187,6 +212,18 @@ class OverrideSampleTests(TransactionTestCase):
             assert not waffle.sample_is_active('foo')
 
         assert not Sample.objects.filter(name='foo').exists()
+
+    def test_cache_is_flushed_by_testutils_even_in_transaction(self):
+        Sample.objects.create(name='foo', percent='100.0')
+
+        with transaction.atomic():
+            with override_sample('foo', active=True):
+                assert waffle.sample_is_active('foo')
+
+            with override_sample('foo', active=False):
+                assert not waffle.sample_is_active('foo')
+
+        assert waffle.sample_is_active('foo')
 
 
 @override_switch('foo', active=False)

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -103,6 +103,7 @@ class override_switch(_overrider):
         obj = self.cls.objects.get(pk=self.obj.pk)
         obj.active = active
         obj.save()
+        obj.flush()
 
     def get_value(self):
         return self.obj.active
@@ -115,6 +116,7 @@ class override_flag(_overrider):
         obj = self.cls.objects.get(pk=self.obj.pk)
         obj.everyone = active
         obj.save()
+        obj.flush()
 
     def get_value(self):
         return self.obj.everyone
@@ -141,6 +143,7 @@ class override_sample(_overrider):
         obj = self.cls.objects.get(pk=self.obj.pk)
         obj.percent = '{0}'.format(p)
         obj.save()
+        obj.flush()
 
     def get_value(self):
         p = self.obj.percent


### PR DESCRIPTION
In test frameworks like `pytest-django`, which wrap test suites in transactions, it isn't possible to set a switch/flag/sample more than once in a test case with `override_switch` and friends.  This appears to be due to the change in 0.15.0 where cache flushes are scheduled to happen in an `on_commit` callback.

This change updates the `testutils` overriders to flush each object's cache, making it predictable to override objects for tests.