### PR TITLE
WIP/RFC: add simple support for multiple checks in template tags

### DIFF
--- a/waffle/templatetags/waffle_tags.py
+++ b/waffle/templatetags/waffle_tags.py
@@ -10,16 +10,22 @@ from waffle.views import _generate_waffle_js
 register = template.Library()
 
 
+# fake logic operator for backward compatibility with single-argument template tags
+def _first(l):
+    return bool(next(iter(l)))
+
+
 class WaffleNode(template.Node):
     child_nodelists = ('nodelist_true', 'nodelist_false')
 
-    def __init__(self, nodelist_true, nodelist_false, condition, name,
-                 compiled_name):
+    def __init__(self, nodelist_true, nodelist_false, condition, names,
+                 compiled_names, logic_op):
         self.nodelist_true = nodelist_true
         self.nodelist_false = nodelist_false
         self.condition = condition
-        self.name = name
-        self.compiled_name = compiled_name
+        self.names = names
+        self.compiled_names = compiled_names
+        self.logic_op = logic_op
 
     def __repr__(self):
         return '<Waffle node: %s>' % self.name
@@ -31,25 +37,27 @@ class WaffleNode(template.Node):
             yield node
 
     def render(self, context):
-        try:
-            name = self.compiled_name.resolve(context)
-        except VariableDoesNotExist:
-            name = self.name
-        if not name:
-            name = self.name
-        if self.condition(context.get('request', None), name):
+        names = self.names
+        for i, name in enumerate(self.compiled_names):
+            try:
+                tmp = name.resolve(context)
+                names[i] = tmp
+            except VariableDoesNotExist:
+                pass  # leave unresolved
+
+        if self.logic_op(map(lambda n: self.condition(context.get('request', None), n), names)):
             return self.nodelist_true.render(context)
         return self.nodelist_false.render(context)
 
     @classmethod
-    def handle_token(cls, parser, token, kind, condition):
+    def handle_token(cls, parser, token, kind, condition, logic_op=_first):
         bits = token.split_contents()
         if len(bits) < 2:
             raise template.TemplateSyntaxError("%r tag requires an argument" %
                                                bits[0])
 
-        name = bits[1]
-        compiled_name = parser.compile_filter(name)
+        names = bits[1:]
+        compiled_names = map(parser.compile_filter, names)
 
         nodelist_true = parser.parse(('else', 'end%s' % kind))
         token = parser.next_token()
@@ -60,7 +68,7 @@ class WaffleNode(template.Node):
             nodelist_false = template.NodeList()
 
         return cls(nodelist_true, nodelist_false, condition,
-                   name, compiled_name)
+                   names, compiled_names, logic_op)
 
 
 @register.tag
@@ -69,13 +77,43 @@ def flag(parser, token):
 
 
 @register.tag
+def flagany(parser, token):
+    return WaffleNode.handle_token(parser, token, 'flagany', flag_is_active, any)
+
+
+@register.tag
+def flagall(parser, token):
+    return WaffleNode.handle_token(parser, token, 'flagall', flag_is_active, all)
+
+
+@register.tag
 def switch(parser, token):
     return WaffleNode.handle_token(parser, token, 'switch', lambda request, name: switch_is_active(name))
 
 
 @register.tag
+def switchany(parser, token):
+    return WaffleNode.handle_token(parser, token, 'switchany', lambda request, name: switch_is_active(name), any)
+
+
+@register.tag
+def switchall(parser, token):
+    return WaffleNode.handle_token(parser, token, 'switchall', lambda request, name: switch_is_active(name), all)
+
+
+@register.tag
 def sample(parser, token):
     return WaffleNode.handle_token(parser, token, 'sample', lambda request, name: sample_is_active(name))
+
+
+@register.tag
+def sampleany(parser, token):
+    return WaffleNode.handle_token(parser, token, 'sampleany', lambda request, name: sample_is_active(name), any)
+
+
+@register.tag
+def sampleall(parser, token):
+    return WaffleNode.handle_token(parser, token, 'sampleall', lambda request, name: sample_is_active(name), all)
 
 
 class InlineWaffleJSNode(template.Node):


### PR DESCRIPTION
This adds support for checking multiple flags/switches/samples in a single template tag. E.g. the following block would be shown when either of the two flags `featureA` or `featureB` is on:
```
{% flagany "featureA" "featureB" %}
...
{% endflagany %}
```

AFAICT, this currently cannot be so easily achieved. The common suggestion in this case seems to be flag nesting, but this is cumbersome because the `else` block would need to be duplicated.

This enables the use case where multiple teams are working on separate feature flags that share some common changes, which - for instance - should be enabled if any of the dependent features flags is enabled.

I'm not sure the current API (introducing separate template tags for each logical operator) is the best solution. It's a compromise to avoid adding full-fledged logical expression parsing to the template tags, which seemed like the easiest approach, but I'm open for other suggestions, of course.

Also, I still didn't add any tests for this :confused: