### PR TITLE
Make `override_switch` usable with coroutines

### DIFF
--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import asyncio
 from decimal import Decimal
 
 from django.contrib.auth.models import AnonymousUser
@@ -60,6 +61,25 @@ class OverrideSwitchTests(TransactionTestCase):
             assert not waffle.switch_is_active('foo')
 
         test_disabled()
+
+        assert not Switch.objects.filter(name='foo').exists()
+
+    def test_as_coroutine_decorator(self):
+        assert not Switch.objects.filter(name='foo').exists()
+
+        loop = asyncio.get_event_loop()
+
+        @override_switch('foo', active=True)
+        async def test_enabled():
+            assert waffle.switch_is_active('foo')
+
+        loop.run_until_complete(test_enabled())
+
+        @override_switch('foo', active=False)
+        async def test_disabled():
+            assert not waffle.switch_is_active('foo')
+
+        loop.run_until_complete(test_disabled())
 
         assert not Switch.objects.filter(name='foo').exists()
 

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import inspect
 import sys
 import types
 from functools import wraps
@@ -24,6 +25,8 @@ class _overrider(object):
     def __call__(self, func):
         if isinstance(func, CLASS_TYPES):
             return self.for_class(func)
+        elif inspect.iscoroutinefunction(func):
+            return self.for_coroutine(func)
         else:
             return self.for_callable(func)
 
@@ -50,6 +53,14 @@ class _overrider(object):
         def _wrapped(*args, **kwargs):
             with self:
                 return func(*args, **kwargs)
+
+        return _wrapped
+
+    def for_coroutine(self, func):
+        @wraps(func)
+        async def _wrapped(*args, **kwargs):
+            with self:
+                return await func(*args, **kwargs)
 
         return _wrapped
 


### PR DESCRIPTION
I've encountered a situation when I needed a wrapper for coroutines. I had to use it in async tests. That's why I create a PR to add the functionality to main repo.

A wrapper for coroutines has to be different than for normal functions.