### PR TITLE
Fix reported version to 0.15.2

### DIFF
--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from waffle.utils import get_setting
 from django.apps import apps as django_apps
 
-VERSION = (0, 13, 0)
+VERSION = (0, 15, 2)
 __version__ = '.'.join(map(str, VERSION))
 default_app_config = 'waffle.apps.WaffleConfig'
 


### PR DESCRIPTION
The version is displayed in e.g. the Django debug panel and is reported incorrectly for 0.15.1, creating slight confusion about the environment.

I set it to 0.15.2 so it will be correct after next release?