### PR TITLE
Remove redundant non-configurarable non-existence log

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -43,7 +43,6 @@ class BaseModel(models.Model):
         cache_key = cls._cache_key(name)
         cached = cache.get(cache_key)
         if cached == CACHE_EMPTY:
-            logger.warning("%s: %s does not exist", cls.__name__, name)
             return cls(name=name)
         if cached:
             return cached


### PR DESCRIPTION
(Partly for discussion, it's possible that having both log lines is useful in a way I haven't noticed)

Ever since https://github.com/django-waffle/django-waffle/pull/310/ was merged, there is a way to configure logging for missing settings, and to not have logging in the case that you don't want to. That mechanism is more functional than this log line.

Though there's a bit of a difference here in that this one will activate on any `get`, whereas the other logger will only activate on `is_active` checks, in practice both should accomplish similar goals

I don't believe that silencing the `waffle` logger as a whole is a great tactic since other log statements might be valuable in the future under this package