### PR TITLE
Flush cache after adding/removing users and groups

### DIFF
--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -7,6 +7,7 @@ from django.apps import apps as django_apps
 
 VERSION = (0, 13, 0)
 __version__ = '.'.join(map(str, VERSION))
+default_app_config = 'waffle.apps.WaffleConfig'
 
 
 def flag_is_active(request, flag_name):

--- a/waffle/apps.py
+++ b/waffle/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class WaffleConfig(AppConfig):
+    name = 'waffle'
+    verbose_name = 'django-waffle'
+
+    def ready(self):
+        import waffle.signals

--- a/waffle/signals.py
+++ b/waffle/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import m2m_changed
+from django.dispatch import receiver
+
+from waffle import get_waffle_flag_model
+
+
+@receiver(m2m_changed, sender=get_waffle_flag_model().users.through)
+@receiver(m2m_changed, sender=get_waffle_flag_model().groups.through)
+def flag_membership_changed(sender, instance, action, **kwargs):
+    if action in ('post_add', 'post_remove'):
+        instance.flush()

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -150,6 +150,12 @@ class WaffleTests(TestCase):
         self.assertEqual(b'off', response.content)
         assert 'dwf_myflag' not in response.cookies
 
+        # Unsetting the flag on a user should have an effect.
+        flag.users.remove(user)
+        request.user = user
+        response = process_request(request, views.flag_in_view)
+        self.assertEqual(b'off', response.content)
+
     def test_group(self):
         """Test the per-group switch."""
         group = Group.objects.create(name='foo')
@@ -170,6 +176,12 @@ class WaffleTests(TestCase):
         response = process_request(request, views.flag_in_view)
         self.assertEqual(b'off', response.content)
         assert 'dwf_myflag' not in response.cookies
+
+        # Unsetting the flag on a group should have an effect.
+        flag.groups.remove(group)
+        request.user = user
+        response = process_request(request, views.flag_in_view)
+        self.assertEqual(b'off', response.content)
 
     def test_authenticated(self):
         """Test the authenticated/anonymous switch."""


### PR DESCRIPTION
Currently, the cached value for a flag is not invalidated when users
or groups are added or removed. This fixes that by registering receivers
for the corresponding m2m_changed signals.

A new signals module is introduced for this purpose, and imported in the
ready method of a new AppConfig class. This is the recommended way of
defining signals in all of the currently supported versions of Django:

https://docs.djangoproject.com/en/1.11/topics/signals/