### PR TITLE
Refactor test_testutils and flush cache on delete

### DIFF
--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -71,6 +71,7 @@ class _overrider(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.created:
             self.obj.delete()
+            self.obj.flush()
         else:
             self.update(self.old_value)
 


### PR DESCRIPTION
The functionality contained within testutils could be used with any
django test case class. This commit therefore expands the tests to cover
TestCase as well as TransactionTestCase from Django.

Doing this reveals a bug that if an object is created by the override_*
helper function then it is not flushed from the cache on deletion. This
commit adds this flush action after the delete has occurred.