### PR TITLE
Allow for inheritance of decorated classes

### DIFF
--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -344,18 +344,30 @@ class OverrideSampleOnClassTransactionTestCase(OverrideSampleOnClassTestsMixin,
 
 
 class InheritanceOverrideSwitchOnClassTests(OverrideSwitchOnClassTestCase):
+    """
+    Extend ``OverrideSwitchOnClassTestCase``
+    and make sure ``override_switch`` change still works.
+    """
 
     def test_child_undecorated_method_is_set_properly_for_switch(self):
         self.assertFalse(waffle.switch_is_active('foo'))
 
 
 class InheritanceOverrideFlagOnClassTests(OverrideFlagOnClassTestCase):
+    """
+    Extend ``OverrideFlagOnClassTestCase``
+    and make sure ``override_flag`` change still works.
+    """
 
     def test_child_undecorated_method_is_set_properly_for_flag(self):
         self.assertFalse(waffle.flag_is_active(req(), 'foo'))
 
 
 class InheritanceOverrideSampleOnClassTests(OverrideSampleOnClassTestCase):
+    """
+    Extend ``OverrideSampleOnClassTestCase``
+    and make sure ``override_sample`` change still works.
+    """
 
     def test_child_undecorated_method_is_set_properly_for_sample(self):
         self.assertFalse(waffle.sample_is_active('foo'))

--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -262,9 +262,10 @@ class OverrideSampleTransactionTestCase(OverrideSampleTestsMixin, TransactionTes
     """
 
 
-@override_switch('foo', active=False)
-class OverrideSwitchOnClassTestsMixin:
-    def setUp(self):
+class OverrideSwitchOnClassTestsMixin(object):
+    @classmethod
+    def setUpClass(cls):
+        super(OverrideSwitchOnClassTestsMixin, cls).setUpClass()
         assert not Switch.objects.filter(name='foo').exists()
         Switch.objects.create(name='foo', active=True)
 
@@ -272,6 +273,7 @@ class OverrideSwitchOnClassTestsMixin:
         self.assertFalse(waffle.switch_is_active('foo'))
 
 
+@override_switch('foo', active=False)
 class OverrideSwitchOnClassTestCase(OverrideSwitchOnClassTestsMixin,
                                     TestCase):
     """
@@ -279,6 +281,7 @@ class OverrideSwitchOnClassTestCase(OverrideSwitchOnClassTestsMixin,
     """
 
 
+@override_switch('foo', active=False)
 class OverrideSwitchOnClassTransactionTestCase(OverrideSwitchOnClassTestsMixin,
                                                TransactionTestCase):
     """
@@ -286,9 +289,10 @@ class OverrideSwitchOnClassTransactionTestCase(OverrideSwitchOnClassTestsMixin,
     """
 
 
-@override_flag('foo', active=False)
-class OverrideFlagOnClassTestsMixin:
-    def setUp(self):
+class OverrideFlagOnClassTestsMixin(object):
+    @classmethod
+    def setUpClass(cls):
+        super(OverrideFlagOnClassTestsMixin, cls).setUpClass()
         assert not waffle.get_waffle_flag_model().objects.filter(name='foo').exists()
         waffle.get_waffle_flag_model().objects.create(name='foo', everyone=True)
 
@@ -296,6 +300,7 @@ class OverrideFlagOnClassTestsMixin:
         self.assertFalse(waffle.flag_is_active(req(), 'foo'))
 
 
+@override_flag('foo', active=False)
 class OverrideFlagOnClassTestCase(OverrideFlagOnClassTestsMixin,
                                   TestCase):
     """
@@ -303,6 +308,7 @@ class OverrideFlagOnClassTestCase(OverrideFlagOnClassTestsMixin,
     """
 
 
+@override_flag('foo', active=False)
 class OverrideFlagOnClassTransactionTestCase(OverrideFlagOnClassTestsMixin,
                                              TransactionTestCase):
     """
@@ -310,9 +316,10 @@ class OverrideFlagOnClassTransactionTestCase(OverrideFlagOnClassTestsMixin,
     """
 
 
-@override_sample('foo', active=False)
-class OverrideSampleOnClassTestsMixin:
-    def setUp(self):
+class OverrideSampleOnClassTestsMixin(object):
+    @classmethod
+    def setUpClass(cls):
+        super(OverrideSampleOnClassTestsMixin, cls).setUpClass()
         assert not Sample.objects.filter(name='foo').exists()
         Sample.objects.create(name='foo', percent='100.0')
 
@@ -320,6 +327,7 @@ class OverrideSampleOnClassTestsMixin:
         self.assertFalse(waffle.sample_is_active('foo'))
 
 
+@override_sample('foo', active=False)
 class OverrideSampleOnClassTestCase(OverrideSampleOnClassTestsMixin,
                                     TestCase):
     """
@@ -327,8 +335,27 @@ class OverrideSampleOnClassTestCase(OverrideSampleOnClassTestsMixin,
     """
 
 
+@override_sample('foo', active=False)
 class OverrideSampleOnClassTransactionTestCase(OverrideSampleOnClassTestsMixin,
                                                TransactionTestCase):
     """
     Run tests with Django TransactionTestCase
     """
+
+
+class InheritanceOverrideSwitchOnClassTests(OverrideSwitchOnClassTestCase):
+
+    def test_child_undecorated_method_is_set_properly_for_switch(self):
+        self.assertFalse(waffle.switch_is_active('foo'))
+
+
+class InheritanceOverrideFlagOnClassTests(OverrideFlagOnClassTestCase):
+
+    def test_child_undecorated_method_is_set_properly_for_flag(self):
+        self.assertFalse(waffle.flag_is_active(req(), 'foo'))
+
+
+class InheritanceOverrideSampleOnClassTests(OverrideSampleOnClassTestCase):
+
+    def test_child_undecorated_method_is_set_properly_for_sample(self):
+        self.assertFalse(waffle.sample_is_active('foo'))

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -1,57 +1,19 @@
 from __future__ import unicode_literals
 
-import sys
-import types
-from functools import wraps
+from django.test.utils import TestContextDecorator
 
 from waffle import get_waffle_flag_model
 from waffle.models import Switch, Sample
 
 
 __all__ = ['override_flag', 'override_sample', 'override_switch']
-PY3 = sys.version_info[0] == 3
-if PY3:
-    CLASS_TYPES = (type,)
-else:
-    CLASS_TYPES = (type, types.ClassType)
 
 
-class _overrider(object):
+class _overrider(TestContextDecorator):
     def __init__(self, name, active):
+        super(_overrider, self).__init__()
         self.name = name
         self.active = active
-
-    def __call__(self, func):
-        if isinstance(func, CLASS_TYPES):
-            return self.for_class(func)
-        else:
-            return self.for_callable(func)
-
-    def for_class(self, obj):
-        """Wraps a class's test methods in the decorator"""
-        for attr in dir(obj):
-            if not attr.startswith('test_'):
-                # Ignore non-test functions
-                continue
-
-            attr_value = getattr(obj, attr)
-
-            if not callable(attr_value):
-                # Ignore non-functions
-                continue
-
-            setattr(obj, attr, self.for_callable(attr_value))
-
-        return obj
-
-    def for_callable(self, func):
-        """Wraps a method in the decorator"""
-        @wraps(func)
-        def _wrapped(*args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-
-        return _wrapped
 
     def get(self):
         self.obj, self.created = self.cls.objects.get_or_create(name=self.name)
@@ -62,13 +24,13 @@ class _overrider(object):
     def get_value(self):
         raise NotImplementedError
 
-    def __enter__(self):
+    def enable(self):
         self.get()
         self.old_value = self.get_value()
         if self.old_value != self.active:
             self.update(self.active)
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def disable(self):
         if self.created:
             self.obj.delete()
             self.obj.flush()


### PR DESCRIPTION
When using `waffle.testutils.override_*` decorators on a class
one would expect the change to be visible on child classes too
(i.e. inheritance would work as normal).

This change drops the rather hacky implementation of
`testutils._overrider.for_class` method in favor of Django's
`django.test.utils.TestContextDecorator`
(the same one that's used as a base for `override_settings` utility).

The most notable change here is that `TestContextDecorator`
hooks up with unittest's `setUp`/`tearDown` mechanism
instead of decorating each test method in a decorated class.

**Backwards incompatible change (!!!):**
Only subclasses of `unittest.case.TestCase` can be decorated
with `testutils.override_*` decorators now.
This means for example that mixin-like test classes (inheriting from
`object` only) can't be decorated like that anymore.