### PR TITLE
Proof of Concept Changes to support filtering flags by CIDR ranges

### DIFF
--- a/waffle/utils.py
+++ b/waffle/utils.py
@@ -1,9 +1,11 @@
 from __future__ import unicode_literals, absolute_import
 
 import hashlib
+import ipaddress
 
 from django.conf import settings
 from django.core.cache import caches
+from ipware import get_client_ip
 
 import waffle
 from waffle import defaults
@@ -28,3 +30,14 @@ def keyfmt(k, v=None):
 def get_cache():
     CACHE_NAME = get_setting('CACHE_NAME')
     return caches[CACHE_NAME]
+
+
+def ip_in_cidr_range(ip, range):
+    network = ipaddress.ip_network(range)
+    return ipaddress.ip_address(ip) in network
+
+
+def request_in_cidr_range(request, range):
+    ip, is_routable = get_client_ip(request)
+
+    return ip_in_cidr_range(ip, range)


### PR DESCRIPTION
I wanted to sketch out what an API/changeset might look like for #37 

TODO:
  - [ ] The ipaddress library is added in Python 3.3 and a backport is available on PyPi for 2.7 users, what should the policy for optional dependencies be for 2.7 users?
  - [ ] django-ipware (https://github.com/un33k/django-ipware) is definitely an external dependency but would only be needed if the CIDR filtering was desired, would it make sense to do a try/except on import to allow it to optionally be installed?
  - [ ] Testing plan, I hacked this together pretty quickly to get the conversation going, it definitely needs more thought before being merged, testing being the highest on the list of things to think through.
  - [ ] Generate/Write migrations for field changes