### PR TITLE
Add support for Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ install:
 services:
   postgresql
 
+addons:
+  postgresql: "9.4"
+
 before_script:
   - psql -c 'create database waffle_test;' -U postgres
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,13 @@
 envlist =
     py{27,34,35,36}-django111
     py{34,35,36,37}-django20
+    py{35,36,37}-django21
 
 [testenv]
 deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     -rtravis.txt
 passenv = DATABASE_URL
 commands =


### PR DESCRIPTION
Add Django 2.1 to `tox.ini`. Tests pass without changes.