### PR TITLE
Improve performance of `is_active_for_user`.

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -377,9 +377,10 @@ class AbstractUserFlag(AbstractBaseFlag):
 
         if hasattr(user, 'groups'):
             group_ids = self._get_group_ids()
-            user_groups = set(user.groups.all().values_list('pk', flat=True))
-            if group_ids.intersection(user_groups):
-                return True
+            if group_ids:
+                user_groups = set(user.groups.all().values_list('pk', flat=True))
+                if group_ids.intersection(user_groups):
+                    return True
 
         return None
 


### PR DESCRIPTION
Howdy! Thanks for a great package.  I have a small change for improving `is_active_for_user` query performance when checking flag enrollment for a flag without groups; namely, skipping the user.groups call (which generally results in a DB call.)

This should be a no-op; `set().intersection(<anything>) == set()`, so this should just be a easy little way to short-circuit.