### PR TITLE
Use correct formatting in logs

### DIFF
--- a/waffle/apps.py
+++ b/waffle/apps.py
@@ -6,4 +6,4 @@ class WaffleConfig(AppConfig):
     verbose_name = 'django-waffle'
 
     def ready(self):
-        import waffle.signals
+        import waffle.signals  # noqa: F401

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -245,8 +245,9 @@ class AbstractBaseFlag(BaseModel):
 
     def is_active(self, request):
         if not self.pk:
-            if get_setting('LOG_MISSING_FLAGS'):
-                logger.log(level=get_setting('LOG_MISSING_FLAGS'), msg=("Flag %s not found", self.name))
+            log_level = get_setting('LOG_MISSING_FLAGS')
+            if log_level:
+                logger.log(log_level, 'Flag %s not found', self.name)
             if get_setting('CREATE_MISSING_FLAGS'):
                 get_waffle_flag_model().objects.get_or_create(
                     name=self.name,
@@ -443,8 +444,9 @@ class Switch(BaseModel):
 
     def is_active(self):
         if not self.pk:
-            if get_setting('LOG_MISSING_SWITCHES'):
-                logger.log(level=get_setting('LOG_MISSING_SWITCHES'), msg=("Switch %s not found", self.name))
+            log_level = get_setting('LOG_MISSING_SWITCHES')
+            if log_level:
+                logger.log(log_level, 'Switch %s not found', self.name)
             if get_setting('CREATE_MISSING_SWITCHES'):
                 Switch.objects.get_or_create(
                     name=self.name,
@@ -507,8 +509,9 @@ class Sample(BaseModel):
 
     def is_active(self):
         if not self.pk:
-            if get_setting('LOG_MISSING_SAMPLES'):
-                logger.log(level=get_setting('LOG_MISSING_SAMPLES'), msg=("Sample %s not found", self.name))
+            log_level = get_setting('LOG_MISSING_SAMPLES')
+            if log_level:
+                logger.log(log_level, 'Sample %s not found', self.name)
             if get_setting('CREATE_MISSING_SAMPLES'):
 
                 default_percent = 100 if get_setting('SAMPLE_DEFAULT') else 0

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -25,6 +25,7 @@ from waffle.tests.base import TestCase
 
 DATABASES = {'default', 'readonly'}
 
+
 def get(**kw):
     request = RequestFactory().get('/foo', data=kw)
     request.user = AnonymousUser()

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -384,7 +384,7 @@ class WaffleTests(TestCase):
     def test_logging_missing_flag(self, mock_logger):
         request = get()
         waffle.flag_is_active(request, 'foo')
-        mock_logger.log.assert_called_with(level=logging.WARNING, msg=('Flag %s not found', 'foo'))
+        mock_logger.log.assert_called_with(logging.WARNING, 'Flag %s not found', 'foo')
 
 
 class SwitchTests(TestCase):
@@ -480,7 +480,7 @@ class SwitchTests(TestCase):
     @mock.patch('waffle.models.logger')
     def test_logging_missing_switch(self, mock_logger):
         waffle.switch_is_active('foo')
-        mock_logger.log.assert_called_with(level=logging.WARNING, msg=('Switch %s not found', 'foo'))
+        mock_logger.log.assert_called_with(logging.WARNING, 'Switch %s not found', 'foo')
 
 
 class SampleTests(TestCase):
@@ -548,7 +548,7 @@ class SampleTests(TestCase):
     @mock.patch('waffle.models.logger')
     def test_logging_missing_sample(self, mock_logger):
         waffle.sample_is_active('foo')
-        mock_logger.log.assert_called_with(level=logging.WARNING, msg=('Sample %s not found', 'foo'))
+        mock_logger.log.assert_called_with(logging.WARNING, 'Sample %s not found', 'foo')
 
 
 class TransactionTestMixin(object):


### PR DESCRIPTION
This PR fixed the way missing flags, switches and samples are logged. It also addresses some flake8 errors that somehow ended up in master.

The original code looked like this:

    logger.log(level=logging.WARNING, msg=("Flag %s not found", self.name))

The logging library will turn whatever is passed to `msg` into a string
and log it like that. This means that the above code would log this, if
`self.name` was 'foo':

    "('Flag %s not found', 'foo')"

The new code no longer uses keyword arguments:

    logger.log(logger.WARNING, 'Flag %s not found', self.name)

This will correctly log it like this: 'Flag foo not found'