### PR TITLE
Add permissions for admin actions.

### DIFF
--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -57,6 +57,10 @@ enable_for_all.short_description = _('Enable selected flags for everyone')
 disable_for_all.short_description = _('Disable selected flags for everyone')
 delete_individually.short_description = _('Delete selected')
 
+enable_for_all.allowed_permissions = ('change',)
+disable_for_all.allowed_permissions = ('change',)
+delete_individually.allowed_permissions = ('delete',)
+
 
 class InformativeManyToManyRawIdWidget(ManyToManyRawIdWidget):
     """Widget for ManyToManyField to Users.
@@ -113,6 +117,9 @@ def disable_switches(ma, request, qs):
 
 enable_switches.short_description = _('Enable selected switches')
 disable_switches.short_description = _('Disable selected switches')
+
+enable_switches.allowed_permissions = ('change',)
+disable_switches.allowed_permissions = ('change',)
 
 
 class SwitchAdmin(BaseAdmin):

--- a/waffle/tests/test_admin.py
+++ b/waffle/tests/test_admin.py
@@ -3,15 +3,21 @@ try:
     import mock
 except ImportError:
     import unittest.mock as mock
+import unittest
 
+import django
 from django.contrib.admin.models import LogEntry, CHANGE, DELETION
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from waffle import get_waffle_flag_model
-from waffle.admin import (FlagAdmin, InformativeManyToManyRawIdWidget, enable_for_all,
+from waffle.admin import (FlagAdmin, SwitchAdmin, InformativeManyToManyRawIdWidget, enable_for_all,
                           disable_for_all, delete_individually, enable_switches, disable_switches)
 from waffle.models import Switch
 from waffle.tests.base import TestCase
+
+
+django_version = tuple(int(d) for d in django.get_version().split("."))
 
 
 class FakeSuperUser:
@@ -21,22 +27,26 @@ class FakeSuperUser:
 
 class FakeRequest:
     def __init__(self):
+        self.GET = {}
         self.user = get_user_model().objects.create(username="test1")
 
 
 Flag = get_waffle_flag_model()
 
 
+skip_if_admin_permissions_not_available = \
+    unittest.skipIf(django_version < (2, 1, 0), "Feature not available")
+
+
 class FlagAdminTests(TestCase):
     def setUp(self):
         self.site = AdminSite()
+        self.flag_admin = FlagAdmin(Flag, self.site)
 
     def test_informative_widget(self):
-        flag_admin = FlagAdmin(Flag, self.site)
-
         request = mock.Mock()
         request.has_perm = lambda self, perm: True
-        form = flag_admin.get_form(request)()
+        form = self.flag_admin.get_form(request)()
         user_widget = form.fields["users"].widget
 
         self.assertIsInstance(user_widget, InformativeManyToManyRawIdWidget)
@@ -79,6 +89,35 @@ class FlagAdminTests(TestCase):
         log_entry = LogEntry.objects.get(user=request.user)
         self.assertEqual(log_entry.action_flag, DELETION)
 
+    @skip_if_admin_permissions_not_available
+    def test_flag_no_actions_without_permissions(self):
+        request = FakeRequest()
+        actions = self.flag_admin.get_actions(request)
+
+        self.assertEqual(actions.keys(), set())
+
+    @skip_if_admin_permissions_not_available
+    def test_flag_action_change(self):
+        request = FakeRequest()
+        request.user.user_permissions.add(Permission.objects.get(codename="change_flag"))
+        actions = self.flag_admin.get_actions(request)
+
+        self.assertEqual(actions.keys(), {"enable_for_all", "disable_for_all"})
+
+    @skip_if_admin_permissions_not_available
+    def test_flag_action_delete(self):
+        request = FakeRequest()
+        request.user.user_permissions.add(Permission.objects.get(codename="delete_flag"))
+        actions = self.flag_admin.get_actions(request)
+
+        self.assertEqual(actions.keys(), {"delete_individually"})
+
+
+class SwitchAdminTests(TestCase):
+    def setUp(self):
+        self.site = AdminSite()
+        self.switch_admin = SwitchAdmin(Switch, self.site)
+
     def test_enable_switches(self):
         s1 = Switch.objects.create(name="switch1", active=False)
 
@@ -102,3 +141,26 @@ class FlagAdminTests(TestCase):
         log_entry = LogEntry.objects.get(user=request.user)
         self.assertEqual(log_entry.action_flag, CHANGE)
         self.assertEqual(log_entry.object_repr, "switch1 off")
+
+    @skip_if_admin_permissions_not_available
+    def test_switch_no_actions_without_permissions(self):
+        request = FakeRequest()
+        actions = self.switch_admin.get_actions(request)
+
+        self.assertEqual(actions.keys(), set())
+
+    @skip_if_admin_permissions_not_available
+    def test_switch_action_change(self):
+        request = FakeRequest()
+        request.user.user_permissions.add(Permission.objects.get(codename="change_switch"))
+        actions = self.switch_admin.get_actions(request)
+
+        self.assertEqual(actions.keys(), {"enable_switches", "disable_switches"})
+
+    @skip_if_admin_permissions_not_available
+    def test_switch_action_delete(self):
+        request = FakeRequest()
+        request.user.user_permissions.add(Permission.objects.get(codename="delete_switch"))
+        actions = self.switch_admin.get_actions(request)
+
+        self.assertEqual(actions.keys(), {"delete_individually"})


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.2/ref/contrib/admin/actions/#setting-permissions-for-actions

Very important since otherwise users who only has view access can still modify flags.