### PR TITLE
Django 3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,31 @@ sudo: false
 
 dist: xenial
 
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "3.8"
-
 matrix:
   include:
-    - python: 3.7
-      env: TOXENV=i18n
+      - { python: "2.7", env: TOXENV=py27-django111-jinja }
+
+      - { python: "3.4", env: TOXENV=py34-django111-jinja }
+      - { python: "3.4", env: TOXENV=py34-django20-jinja }
+
+      - { python: "3.5", env: TOXENV=py35-django111-jinja }
+      - { python: "3.5", env: TOXENV=py35-django20-jinja }
+
+      - { python: "3.6", env: TOXENV=py36-django111-jinja }
+      - { python: "3.6", env: TOXENV=py36-django20-jinja }
+      - { python: "3.6", env: TOXENV=py36-django21-jinja }
+      - { python: "3.6", env: TOXENV=py36-django22-jinja }
+      - { python: "3.6", env: TOXENV=py36-django30 }
+
+      - { python: "3.7", env: TOXENV=py37-django20-jinja }
+      - { python: "3.7", env: TOXENV=py37-django21-jinja }
+      - { python: "3.7", env: TOXENV=py37-django22-jinja }
+      - { python: "3.7", env: TOXENV=py37-django30 }
+
+      - { python: "3.8", env: TOXENV=py38-django22-jinja }
+      - { python: "3.8", env: TOXENV=py38-django30 }
+
+      - { python: "3.8", env: TOXENV=i18n }
 
 install:
   - pip install tox tox-travis

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Waffle Changelog
 v0.19.0
 =======
 - Made tests for jinja2 optional while waiting for django-jinja to be compatible with django 3.0.
+- Add support for Django 3.0 by removing use of deprecated functionality from Django 2.2.
 
 v0.18.0
 =======

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # These are required to run the tests.
 Django
 flake8
+six
 
 # Everything else is in a Django-version-free version
 # for TravisCI.

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ]
+    ],
+    install_requires=['six>=1.13.0']
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{34,35,36,37}-django20-jinja
     py{35,36,37}-django21-jinja
     py{35,36,37,38}-django22-jinja
+    py{36,37,38}-django30
 
 [testenv]
 deps =
@@ -12,6 +13,7 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     jinja: -rtravis_jinja.txt
+    django30: Django>=3.0,<3.1
     -rtravis.txt
 passenv = DATABASE_URL
 commands =

--- a/waffle/decorators.py
+++ b/waffle/decorators.py
@@ -1,18 +1,17 @@
 from __future__ import unicode_literals
 
-from functools import wraps
+from functools import wraps, WRAPPER_ASSIGNMENTS
 
 from django.http import Http404
 from django.shortcuts import redirect
 from django.urls import reverse, NoReverseMatch
-from django.utils.decorators import available_attrs
 
 from waffle import flag_is_active, switch_is_active
 
 
 def waffle_flag(flag_name, redirect_to=None):
     def decorator(view):
-        @wraps(view, assigned=available_attrs(view))
+        @wraps(view, assigned=WRAPPER_ASSIGNMENTS)
         def _wrapped_view(request, *args, **kwargs):
             if flag_name.startswith('!'):
                 active = not flag_is_active(request, flag_name[1:])
@@ -33,7 +32,7 @@ def waffle_flag(flag_name, redirect_to=None):
 
 def waffle_switch(switch_name, redirect_to=None):
     def decorator(view):
-        @wraps(view, assigned=available_attrs(view))
+        @wraps(view, assigned=WRAPPER_ASSIGNMENTS)
         def _wrapped_view(request, *args, **kwargs):
             if switch_name.startswith('!'):
                 active = not switch_is_active(switch_name[1:])

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -8,9 +8,9 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db import models, router, transaction
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
+from six import python_2_unicode_compatible
 from waffle import managers, get_waffle_flag_model
 from waffle.utils import get_setting, keyfmt, get_cache
 


### PR DESCRIPTION
Closes #354.

Django 3 ["remove[s] private Python 2 compatibility APIs"](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis), which is to say it removes a number of utility methods that were either already provided by `six` or otherwise were used in bridging the old and the new python.  This pull request makes `django-waffle` work with Django 3 by making just 3 changes.

1. Add `six` to the requirements.
2. Replace the result of calling`available_attrs` with `functools.WRAPPER_ASSIGNMENTS` (cf https://docs.djangoproject.com/en/2.2/_modules/django/utils/decorators/)
3. Use the `python_2_unicode_compatible` provided by `six` rather than the one vendored with django.

Not sure what the protocol is on bumping the version and amending the changelog; would be happy to do both.