### PR TITLE
Made optional to test jinja2 due to django-jinja being unmaintained

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 matrix:
   include:

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,10 @@
 Waffle Changelog
 ================
 
+v0.19.0
+=======
+- Made tests for jinja2 optional while waiting for django-jinja to be compatible with django 3.0.
+
 v0.18.0
 =======
 - Updated `MIDDLEWARE` setting name for Django 1.10+

--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -52,6 +52,10 @@ Add ``waffle`` to the ``INSTALLED_APPS`` setting, and
 Jinja Templates
 ---------------
 
+.. versionchanged:: 0.19
+If you are using Jinja2 templates, the ``django-jinja`` dependency is currently
+unavailable with django 3.0 and greater; 2.x versions are compatible as well as 1.11.
+
 .. versionchanged:: 0.11
 
 If you're using Jinja2 templates, Waffle provides a Jinja2 extension

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,6 +1,13 @@
 import os
 
 
+try:
+    import django_jinja
+    JINJA_INSTALLED = True
+except ImportError:
+    JINJA_INSTALLED = False
+
+
 # Make filepaths relative to settings.
 ROOT = os.path.dirname(os.path.abspath(__file__))
 path = lambda *a: os.path.join(ROOT, *a)
@@ -66,24 +73,31 @@ _CONTEXT_PROCESSORS = (
     'django.contrib.messages.context_processors.messages',
 )
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django_jinja.backend.Jinja2',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'match_regex': r'jinja.*',
-            'match_extension': '',
-            'newstyle_gettext': True,
-            'context_processors': _CONTEXT_PROCESSORS,
-            'undefined': 'jinja2.Undefined',
-            'extensions': [
-                'jinja2.ext.i18n',
-                'jinja2.ext.autoescape',
-                'waffle.jinja.WaffleExtension',
-            ],
+
+if JINJA_INSTALLED:
+    TEMPLATES = [
+        {
+            'BACKEND': 'django_jinja.backend.Jinja2',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'match_regex': r'jinja.*',
+                'match_extension': '',
+                'newstyle_gettext': True,
+                'context_processors': _CONTEXT_PROCESSORS,
+                'undefined': 'jinja2.Undefined',
+                'extensions': [
+                    'jinja2.ext.i18n',
+                    'jinja2.ext.autoescape',
+                    'waffle.jinja.WaffleExtension',
+                ],
+            }
         }
-    },
+    ]
+else:
+    TEMPLATES = []
+
+TEMPLATES.append(
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [],
@@ -92,8 +106,9 @@ TEMPLATES = [
             'debug': DEBUG,
             'context_processors': _CONTEXT_PROCESSORS,
         }
-    },
-]
+    }
+)
+
 
 WAFFLE_FLAG_DEFAULT = False
 WAFFLE_SWITCH_DEFAULT = False

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django111
-    py{34,35,36,37}-django20
-    py{35,36,37}-django21
-    py{35,36,37}-django22
+    py{27,34,35,36}-django111-jinja
+    py{34,35,36,37}-django20-jinja
+    py{35,36,37}-django21-jinja
+    py{35,36,37,38}-django22-jinja
 
 [testenv]
 deps =
@@ -11,12 +11,16 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    jinja: -rtravis_jinja.txt
     -rtravis.txt
 passenv = DATABASE_URL
 commands =
     ./run.sh test
 
 [testenv:i18n]
+deps =
+    Django>=2.2,<2.3
+    -rtravis.txt
 commands =
     ./run.sh makemessages
     ./run.sh compilemessages

--- a/travis.txt
+++ b/travis.txt
@@ -1,9 +1,7 @@
 # These are the requirements for Travis, e.g. we don't specify Django
 # versions.
 mock==1.3.0
-Jinja2>=2.7.1
 dj-database-url==0.5.0
-django-jinja>=2.1,<3
 psycopg2-binary>=2.7.7
 
 transifex-client

--- a/travis_jinja.txt
+++ b/travis_jinja.txt
@@ -1,0 +1,2 @@
+Jinja2>=2.7.1
+django-jinja>=2.1,<3

--- a/waffle/tests/test_templates.py
+++ b/waffle/tests/test_templates.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
+from unittest import skipUnless
 
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.template import Template
 from django.template.base import VariableNode
@@ -54,6 +56,10 @@ class WaffleTemplateTests(TestCase):
         assert 'switch off' in content
         assert 'sample' in content
 
+    @skipUnless(
+        settings.JINJA_INSTALLED,
+        "django-jinja is currently unmaintained and uncompatible with django >= 3.0"
+    )
     def test_jinja_tags(self):
         request = get()
         response = process_request(request, views.flag_in_jinja)


### PR DESCRIPTION
This change makes `django-jinja` as an optional feature thus can be skipped in tests.
All compatible django versions are still tested against jinja.

In #355, we can add `TOXENV='py{36,37,38}-django30-jinja'` to the test matrix and mark it as an allowed failure. When adding django 3.0, we will have `py{36,37,38}-django30` in the tox file to skip the jinja tests.