### PR TITLE
Remove note about dropping support for Django 2.2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Waffle Changelog
 
 v0.19.0
 =======
-- Dropped support for Django 2.1, and Python 3.4
+- Dropped support for Django 2.0, 2.1, and Python 3.4.
 - Made tests for Jinja2 optional while waiting for django-jinja to be compatible with Django 3.0.
 - Add support for Django 3.0 by removing use of deprecated functionality from Django 2.2.
 

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Waffle Changelog
 
 v0.19.0
 =======
-- Dropped support for Django 2.1 and 2.2, and Python 3.4
+- Dropped support for Django 2.1, and Python 3.4
 - Made tests for Jinja2 optional while waiting for django-jinja to be compatible with Django 3.0.
 - Add support for Django 3.0 by removing use of deprecated functionality from Django 2.2.
 


### PR DESCRIPTION
Django 2.2 is still in LTS and is supported until April 2022. See: https://www.djangoproject.com/download/
So, django-waffle shouldn't drop support for it before then.

django-waffle is still being tested on Django 1.11 and Django 2.2. https://github.com/django-waffle/django-waffle/blob/master/.travis.yml#L9