### PR TITLE
Fix a few docs typos

### DIFF
--- a/docs/starting/configuring.rst
+++ b/docs/starting/configuring.rst
@@ -71,7 +71,7 @@ behavior.
 
 ``WAFFLE_CREATE_MISSING_SWITCHES``
     If Waffle encounters a reference to a switch that is not in the database, should Waffle create the sample?
-    If true new switchs are created and set to the value of ``WAFFLE_SWITCH_DEFAULT``
+    If true new switches are created and set to the value of ``WAFFLE_SWITCH_DEFAULT``
     Defaults to ``False``.
 
 ``WAFFLE_CREATE_MISSING_SAMPLES``

--- a/docs/types/flag.rst
+++ b/docs/types/flag.rst
@@ -47,7 +47,7 @@ Flags can be administered through the Django `admin site`_ or the
     The name of the flag. Will be used to identify the flag everywhere.
 :Everyone:
     Globally set the Flag, **overriding all other criteria**. Leave as
-    *Unknown* to use other critera.
+    *Unknown* to use other criteria.
 :Testing:
     Can the flag be specified via a querystring parameter? :ref:`See
     below <types-flag-testing>`.
@@ -231,7 +231,7 @@ auto-created database record.
 Log Missing
 ===================
 
-Wether or not you enabled :ref:`Auto Create Missing Flags <types-flag-auto-create-missing>`,
+Whether or not you enabled :ref:`Auto Create Missing Flags <types-flag-auto-create-missing>`,
 it can be practical to be informed that a flag was or is missing.
 If you'd like waffle to log a warning, error, ... you can set :ref:`WAFFLE_LOG_MISSING_FLAGS
 <starting-configuring>` to any level known by Python default logger.

--- a/docs/types/sample.rst
+++ b/docs/types/sample.rst
@@ -76,7 +76,7 @@ always evaluates to ``False``.
 Log Missing
 ===================
 
-Wether or not you enabled :ref:`Auto Create Missing Sample <types-sample-auto-create-missing>`,
+Whether or not you enabled :ref:`Auto Create Missing Sample <types-sample-auto-create-missing>`,
 it can be practical to be informed that a sample was or is missing.
 If you'd like waffle to log a warning, error, ... you can set :ref:`WAFFLE_LOG_MISSING_SAMPLES
 <starting-configuring>` to any level known by Python default logger.

--- a/docs/types/switch.rst
+++ b/docs/types/switch.rst
@@ -33,7 +33,7 @@ Auto Create Missing
 When a switch is evaluated in code that is missing in the database the
 switch returns the :ref:`WAFFLE_SWITCH_DEFAULT <starting-configuring>`
 value but does not create a switch in the database. If you'd like waffle
-to create missing switchs in the database whenever it encounters a
+to create missing switches in the database whenever it encounters a
 missing switch you can set :ref:`WAFFLE_CREATE_MISSING_SWITCHES
 <starting-configuring>` to ``True``. Missing switches will be created in
 the database and the value of the ``Active`` switch attribute will be
@@ -46,7 +46,7 @@ auto-created database record.
 Log Missing
 ===================
 
-Wether or not you enabled :ref:`Auto Create Missing Switch <types-switch-auto-create-missing>`,
+Whether or not you enabled :ref:`Auto Create Missing Switch <types-switch-auto-create-missing>`,
 it can be practical to be informed that a switch was or is missing.
 If you'd like waffle to log a warning, error, ... you can set :ref:`WAFFLE_LOG_MISSING_FLAGS
 <starting-configuring>` to any level known by Python default logger.


### PR DESCRIPTION
Found with [codespell](https://github.com/codespell-project/codespell)