### PR TITLE
Use gettext_lazy instead of ugettext_lazy.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,10 @@
 Waffle Changelog
 ================
 
+v0.19.1
+=======
+- Removed deprection warnings for ugettext.
+
 v0.19.0
 =======
 - Dropped support for Django 2.0, 2.1, and Python 3.4.

--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -1,11 +1,15 @@
 from __future__ import unicode_literals
 
+import six
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry, CHANGE, DELETION
 from django.contrib.admin.widgets import ManyToManyRawIdWidget
 from django.contrib.contenttypes.models import ContentType
 from django.utils.html import escape
-from django.utils.translation import ugettext_lazy as _
+if six.PY2:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 
 from waffle.models import Flag, Sample, Switch
 

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -4,11 +4,15 @@ import random
 from decimal import Decimal
 import logging
 
+import six
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db import models, router, transaction
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+if six.PY2:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 
 from six import python_2_unicode_compatible
 from waffle import managers, get_waffle_flag_model


### PR DESCRIPTION
Removes a ton of warnings in Django 3.