### PR TITLE
Dropped support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,16 @@ dist: bionic
 
 matrix:
   include:
-      - { python: "2.7", env: TOXENV=py27-django111-jinja }
+      - { python: "3.5", env: TOXENV=py35-django111 }
 
-      - { python: "3.5", env: TOXENV=py35-django111-jinja }
-
-      - { python: "3.6", env: TOXENV=py36-django111-jinja }
-      - { python: "3.6", env: TOXENV=py36-django22-jinja }
+      - { python: "3.6", env: TOXENV=py36-django111 }
+      - { python: "3.6", env: TOXENV=py36-django22 }
       - { python: "3.6", env: TOXENV=py36-django30 }
 
-      - { python: "3.7", env: TOXENV=py37-django22-jinja }
+      - { python: "3.7", env: TOXENV=py37-django22 }
       - { python: "3.7", env: TOXENV=py37-django30 }
 
-      - { python: "3.8", env: TOXENV=py38-django22-jinja }
+      - { python: "3.8", env: TOXENV=py38-django22 }
       - { python: "3.8", env: TOXENV=py38-django30 }
 
       - { python: "3.8", env: TOXENV=i18n }

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Waffle Changelog
 
 v0.19.1
 =======
-- Removed deprection warnings for ugettext.
+- Dropped support for Python 2.7
+- Removed deprecation warnings for ugettext.
 
 v0.19.0
 =======

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     package_data={'': ['README.rst']},
     zip_safe=False,
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
         'Intended Audience :: Developers',
@@ -25,8 +25,6 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 3.0',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django111-jinja
-    py{34,35,36,37}-django20-jinja
-    py{35,36,37}-django21-jinja
-    py{35,36,37,38}-django22-jinja
+    py{35,36}-django111
+    py{35,36,37}-django20
+    py{35,36,37}-django21
+    py{35,36,37,38}-django22
     py{36,37,38}-django30
 
 [testenv]
@@ -12,7 +12,6 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    jinja: -rtravis_jinja.txt
     django30: Django>=3.0,<3.1
     -rtravis.txt
 passenv = DATABASE_URL
@@ -21,7 +20,7 @@ commands =
 
 [testenv:i18n]
 deps =
-    Django>=2.2,<2.3
+    Django>=3.0,<3.1
     -rtravis.txt
 commands =
     ./run.sh makemessages

--- a/travis.txt
+++ b/travis.txt
@@ -1,7 +1,6 @@
-# These are the requirements for Travis, e.g. we don't specify Django
-# versions.
-mock==1.3.0
 dj-database-url==0.5.0
+django-jinja>=2.4.1,<3
+Jinja2>=2.7.1
+mock==1.3.0
 psycopg2-binary>=2.7.7
-
 transifex-client

--- a/travis_jinja.txt
+++ b/travis_jinja.txt
@@ -1,2 +1,0 @@
-Jinja2>=2.7.1
-django-jinja>=2.1,<3


### PR DESCRIPTION
This is the simplest way to fix Jinja testing without having to do requirements shenanigans. Python 2.7+Django 1.11 may still work, but we will no longer guarantee support for that combination of Python and Django. Additionally, we are now using the latest version of django-jinja in our testing.