### PR TITLE
Docs : Fixed typo for waffle sample for mixins.

### DIFF
--- a/docs/usage/mixins.rst
+++ b/docs/usage/mixins.rst
@@ -39,4 +39,4 @@ WaffleSampleMixin
     from waffle.mixins import WaffleSampleMixin
 
     class MyClass(WaffleSampleMixin, View):
-        waffle_switch= "my_sample"
+        waffle_sample= "my_sample"


### PR DESCRIPTION
Fixes a typo for the `WaffleSampleMixin`