### PR TITLE
Fix caching of auto-created missing flags

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -252,7 +252,7 @@ class AbstractBaseFlag(BaseModel):
                     }
                 )
                 cache = get_cache()
-                cache.add(self._cache_key(self.name), flag)
+                cache.set(self._cache_key(self.name), flag)
 
             return get_setting('FLAG_DEFAULT')
 
@@ -453,7 +453,7 @@ class Switch(BaseModel):
                     }
                 )
                 cache = get_cache()
-                cache.add(self._cache_key(self.name), switch)
+                cache.set(self._cache_key(self.name), switch)
 
             return get_setting('SWITCH_DEFAULT')
 
@@ -523,7 +523,7 @@ class Sample(BaseModel):
                     }
                 )
                 cache = get_cache()
-                cache.add(self._cache_key(self.name), sample)
+                cache.set(self._cache_key(self.name), sample)
 
             return get_setting('SAMPLE_DEFAULT')
         return Decimal(str(random.uniform(0, 100))) <= self.percent


### PR DESCRIPTION
Embarrassing follow-up to #379. It turns out the caching didn't actually work in some circumstances, because of the use of put() instead of set() -- the former does nothing when the key already exists. The test added in that PR passes for complicated reasons: `get_or_create` calls save() which is hooked to flush caches on transaction commit, and due to how transactions are set up in the test runner this occurs just in time for the call to put().

In a test suite at work, the flush doesn't happen before put(), so put() does nothing and we get one DB query per "flag_is_active" check. I don't know Django well enough to know how the two scenarios differ exactly. Django's "run tests in rolled-back transactions" behavior is probably involved somehow. I wouldn't be surprised if the buggy behavior is test-only.

Anyway, this makes the code more obviously correct and helps with the test suite at work. I don't really know how to test this...