### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,23 @@ matrix:
       - { python: "3.8", env: TOXENV=py38-django31 }
 
       - { python: "3.7", env: TOXENV=i18n }
+      
+      # Adding power support architecture
+      - { arch: "ppc64le", python: "3.5", env: TOXENV=py35-django22, addons: {postgresql: "10"} }
+
+      - { arch: "ppc64le", python: "3.6", env: TOXENV=py36-django22, addons: {postgresql: "10"} }
+      - { arch: "ppc64le", python: "3.6", env: TOXENV=py36-django30, addons: {postgresql: "10"} }
+      - { arch: "ppc64le", python: "3.6", env: TOXENV=py36-django31, addons: {postgresql: "10"} }
+
+      - { arch: "ppc64le", python: "3.7", env: TOXENV=py37-django22, addons: {postgresql: "10"} }
+      - { arch: "ppc64le", python: "3.7", env: TOXENV=py37-django30, addons: {postgresql: "10"} }
+      - { arch: "ppc64le", python: "3.7", env: TOXENV=py37-django31, addons: {postgresql: "10"} }
+
+      - { arch: "ppc64le", python: "3.8", env: TOXENV=py38-django22, addons: {postgresql: "10"} }
+      - { arch: "ppc64le", python: "3.8", env: TOXENV=py38-django30, addons: {postgresql: "10"} }
+      - { arch: "ppc64le", python: "3.8", env: TOXENV=py38-django31, addons: {postgresql: "10"} }
+
+      - { arch: "ppc64le", python: "3.7", env: TOXENV=i18n, addons: {postgresql: "10"} }
 
 install:
   - pip install tox tox-travis
@@ -35,6 +52,7 @@ addons:
   postgresql: "9.6"
 
 before_script:
+  - sudo apt-get install -y gettext-base gettext
   - psql -c 'create database waffle_test;' -U postgres
 
 env:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.