### PR TITLE
Add support for Django 3.2

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,17 +17,17 @@ shift
 
 case "$CMD" in
     "test" )
-        DJANGO_SETTINGS_MODULE=test_settings django-admin.py test waffle $@ ;;
+        DJANGO_SETTINGS_MODULE=test_settings django-admin test waffle $@ ;;
     "lint" )
         flake8 waffle $@ ;;
     "shell" )
-        django-admin.py shell $@ ;;
+        django-admin shell $@ ;;
     "makemigrations" )
-        django-admin.py makemigrations waffle $@ ;;
+        django-admin makemigrations waffle $@ ;;
     "makemessages" )
-        export DJANGO_SETTINGS_MODULE= && cd waffle && django-admin.py makemessages --all && cd - ;;
+        export DJANGO_SETTINGS_MODULE= && cd waffle && django-admin makemessages --all && cd - ;;
     "compilemessages" )
-        export DJANGO_SETTINGS_MODULE= && cd waffle && django-admin.py compilemessages && cd - ;;
+        export DJANGO_SETTINGS_MODULE= && cd waffle && django-admin compilemessages && cd - ;;
     "find_uncommitted_translations" )
         git diff --exit-code -G "^(msgid|msgstr)" || (echo "Please run ./run.sh makemessages and commit the updated django.po file." && false) ;;
     * )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',

--- a/test_settings.py
+++ b/test_settings.py
@@ -35,6 +35,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py35-django22
-    py{36,37,38,39}-django{22,30,31}
+    py{36,37,38,39}-django{22,30,31,32}
     py{38,39}-django{main}
 
 [gh-actions]
@@ -17,6 +17,7 @@ deps =
     django22: Django>=2.2,<2.3
 	django30: Django>=3.0,<3.1
 	django31: Django>=3.1,<3.2
+	django32: Django>=3.2,<3.3
 	djangomain: https://github.com/django/django/archive/main.tar.gz
 	-r{toxinidir}/requirements.txt
 commands =
@@ -24,7 +25,7 @@ commands =
 
 [testenv:i18n]
 deps =
-	Django>=3.1,<3.2
+	Django>=3.1,<3.3
 	-r{toxinidir}/requirements.txt
 commands =
     ./run.sh makemessages

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     py35-django22
     py{36,37,38,39}-django{22,30,31,32}
-    py{38,39}-django{main}
 
 [gh-actions]
 python =

--- a/waffle/apps.py
+++ b/waffle/apps.py
@@ -4,6 +4,7 @@ from django.apps import AppConfig
 class WaffleConfig(AppConfig):
     name = 'waffle'
     verbose_name = 'django-waffle'
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         import waffle.signals  # noqa: F401


### PR DESCRIPTION
- Configure default auto field for waffle and test_app - Django 3.2 adds
  the ability to customise the type of auto-created primary key fields.
- Add Django 3.2 to tox.ini and setup.py

Addresses #395
Fixes #396