### PR TITLE
WIP: Update migrations to remove NullBooleanField

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py35-django22
-    py{36,37,38,39}-django{22,30,31,32}
+    py{36,37,38,39}-django{22,30,31,32,main}
 
 [gh-actions]
 python =

--- a/waffle/migrations/0001_initial.py
+++ b/waffle/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(help_text='The human/computer readable name.', unique=True, max_length=100)),
-                ('everyone', models.NullBooleanField(help_text='Flip this flag on (Yes) or off (No) for everyone, overriding all other settings. Leave as Unknown to use normally.')),
+                ('everyone', models.BooleanField(help_text='Flip this flag on (Yes) or off (No) for everyone, overriding all other settings. Leave as Unknown to use normally.', null=True)),
                 ('percent', models.DecimalField(help_text='A number between 0.0 and 99.9 to indicate a percentage of users for whom this flag will be active.', null=True, max_digits=3, decimal_places=1, blank=True)),
                 ('testing', models.BooleanField(default=False, help_text='Allow this flag to be set for a session for user testing.')),
                 ('superusers', models.BooleanField(default=True, help_text='Flag always active for superusers?')),

--- a/waffle/migrations/0003_update_strings_for_i18n.py
+++ b/waffle/migrations/0003_update_strings_for_i18n.py
@@ -37,7 +37,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='flag',
             name='everyone',
-            field=models.NullBooleanField(help_text='Flip this flag on (Yes) or off (No) for everyone, overriding all other settings. Leave as Unknown to use normally.', verbose_name='Everyone'),
+            field=models.BooleanField(help_text='Flip this flag on (Yes) or off (No) for everyone, overriding all other settings. Leave as Unknown to use normally.', null=True, verbose_name='Everyone'),
         ),
         migrations.AlterField(
             model_name='flag',


### PR DESCRIPTION
Creating this PR to run CI - WIP.

This commit retroactively edits the 0001 and 0003 migrations
to remove NullBooleanField references, as this field was
deprecated in Django 3, and is causing Django 4 tests to fail.

Fixes issue #411 
