### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/waffle/tests/test_management.py
+++ b/waffle/tests/test_management.py
@@ -33,7 +33,7 @@ class WaffleFlagManagementCommandTests(TestCase):
         not set.
         """
         name = 'test'
-        with self.assertRaisesRegexp(CommandError, 'This flag does not exist.'):
+        with self.assertRaisesRegex(CommandError, 'This flag does not exist.'):
             call_command('waffle_flag', name, everyone=True, percent=20,
                          superusers=True, staff=True, authenticated=True,
                          rollout=True)
@@ -204,7 +204,7 @@ class WaffleSampleManagementCommandTests(TestCase):
         not set.
         """
         name = 'test'
-        with self.assertRaisesRegexp(CommandError, 'This sample does not exist'):
+        with self.assertRaisesRegex(CommandError, 'This sample does not exist'):
             call_command('waffle_sample', name, '20')
         self.assertFalse(Sample.objects.filter(name=name).exists())
 
@@ -248,7 +248,7 @@ class WaffleSwitchManagementCommandTests(TestCase):
         not set.
         """
         name = 'test'
-        with self.assertRaisesRegexp(CommandError, 'This switch does not exist.'):
+        with self.assertRaisesRegex(CommandError, 'This switch does not exist.'):
             call_command('waffle_switch', name, 'on')
         self.assertFalse(Switch.objects.filter(name=name).exists())
 

--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -199,7 +199,7 @@ class OverrideSampleTestsMixin:
         with override_sample('foo', active=False):
             assert not waffle.sample_is_active('foo')
 
-        self.assertEquals(Decimal('100.0'),
+        self.assertEqual(Decimal('100.0'),
                           Sample.objects.get(name='foo').percent)
 
     def test_sample_existed_and_was_0(self):
@@ -211,7 +211,7 @@ class OverrideSampleTestsMixin:
         with override_sample('foo', active=False):
             assert not waffle.sample_is_active('foo')
 
-        self.assertEquals(Decimal('0.0'),
+        self.assertEqual(Decimal('0.0'),
                           Sample.objects.get(name='foo').percent)
 
     def test_sample_existed_and_was_50(self):
@@ -223,7 +223,7 @@ class OverrideSampleTestsMixin:
         with override_sample('foo', active=False):
             assert not waffle.sample_is_active('foo')
 
-        self.assertEquals(Decimal('50.0'),
+        self.assertEqual(Decimal('50.0'),
                           Sample.objects.get(name='foo').percent)
 
     def test_sample_did_not_exist(self):


### PR DESCRIPTION
Deprecated unittest aliases were removed in Python 3.11 . This will cause error when tests are executed in Python 3.11 .

Ref : python/cpython#28268

assertEquals -> assertEqual
assertRaisesRegexp -> assertRaisesRegex