### PR TITLE
Make CREATE_MISSING_FLAGS logic universal (#400)

### DIFF
--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -441,6 +441,16 @@ class WaffleTests(TestCase):
     def test_flag_created_dynamically_default_true(self):
         self.assert_flag_dynamically_created_with_value(True)
 
+    @override_settings(WAFFLE_CREATE_MISSING_FLAGS=True)
+    @override_settings(WAFFLE_FLAG_DEFAULT=True)
+    def test_flag_created_dynamically_upon_retrieval(self):
+        FLAG_NAME = 'myflag'
+        flag_model = waffle.get_waffle_flag_model()
+        flag = flag_model.get(FLAG_NAME)
+
+        assert flag.is_active(get())
+        assert flag_model.objects.filter(name=FLAG_NAME).exists()
+
     @mock.patch('waffle.models.logger')
     def test_no_logging_missing_flag_by_default(self, mock_logger):
         request = get()


### PR DESCRIPTION
Before CREATE_MISSING_FLAGS was only respected when `is_active(request)` method was used, now any check against a flag (calling `get(name)`) will trigger the automatic creation of the `Flag` model.

Fixes #400 