### PR TITLE
Django 4.0 compatibility

### DIFF
--- a/test_app/models.py
+++ b/test_app/models.py
@@ -1,7 +1,12 @@
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.db import models
 from django.db.models import CASCADE
-from django.utils.translation import ugettext_lazy as _
+
+# ugettext variants removed in Django 4.0. Only gettext now available
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from waffle.models import AbstractUserFlag, CACHE_EMPTY
 from waffle.utils import get_setting, keyfmt, get_cache

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls import url, include
+try:
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import re_path as url
+from django.urls import include
 from django.contrib import admin
 from django.http import HttpResponseNotFound, HttpResponseServerError
 

--- a/waffle/tests/test_mixin.py
+++ b/waffle/tests/test_mixin.py
@@ -14,9 +14,13 @@ def get(**kw):
     return request
 
 
+def get_response(request):
+    return 'hello'
+
+
 def process_request(request, view):
     response = view.as_view()(request)
-    return WaffleMiddleware().process_response(request, response)
+    return WaffleMiddleware(get_response).process_response(request, response)
 
 
 class WaffleFlagMixinTest(TestCase):

--- a/waffle/tests/test_templates.py
+++ b/waffle/tests/test_templates.py
@@ -17,13 +17,16 @@ def get():
     return request
 
 
+def get_response(request):
+    return 'hello'
+
+
 def process_request(request, view):
     response = view(request)
-    return WaffleMiddleware().process_response(request, response)
+    return WaffleMiddleware(get_response).process_response(request, response)
 
 
 class WaffleTemplateTests(TestCase):
-
     def test_django_tags(self):
         request = get()
         response = process_request(request, views.flag_in_django)

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -30,9 +30,13 @@ def get(**kw):
     return request
 
 
+def get_response(request):
+    return 'hello'
+
+
 def process_request(request, view):
     response = view(request)
-    return WaffleMiddleware().process_response(request, response)
+    return WaffleMiddleware(get_response).process_response(request, response)
 
 
 class WaffleTests(TestCase):


### PR DESCRIPTION
The test suite fails on Django 4.0 on trunk.  Fixes were pretty simple: two deprecated imports (one present only in the test app) had finally been removed, and support had been removed for the way the middleware was instantiated in the tests.