### PR TITLE
Pluggable Switch and Sample models #456

### DIFF
--- a/waffle/management/commands/waffle_delete.py
+++ b/waffle/management/commands/waffle_delete.py
@@ -1,7 +1,10 @@
 from django.core.management.base import BaseCommand
 
-from waffle import get_waffle_flag_model
-from waffle.models import Sample, Switch
+from waffle import (
+    get_waffle_flag_model,
+    get_waffle_switch_model,
+    get_waffle_sample_model,
+)
 
 
 class Command(BaseCommand):
@@ -37,14 +40,16 @@ class Command(BaseCommand):
 
         switches = options['switch_names']
         if switches:
-            switches_queryset = Switch.objects.filter(name__in=switches)
+            switches_queryset = get_waffle_switch_model().objects.filter(
+                name__in=switches
+            )
             switch_count = switches_queryset.count()
             switches_queryset.delete()
             self.stdout.write('Deleted %s Switches' % switch_count)
 
         samples = options['sample_names']
         if samples:
-            sample_queryset = Sample.objects.filter(name__in=samples)
+            sample_queryset = get_waffle_sample_model().objects.filter(name__in=samples)
             sample_count = sample_queryset.count()
             sample_queryset.delete()
             self.stdout.write('Deleted %s Samples' % sample_count)

--- a/waffle/management/commands/waffle_sample.py
+++ b/waffle/management/commands/waffle_sample.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
-from waffle.models import Sample
-
+from waffle import get_waffle_sample_model
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
@@ -30,7 +29,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options['list_samples']:
             self.stdout.write('Samples:')
-            for sample in Sample.objects.iterator():
+            for sample in get_waffle_sample_model().objects.iterator():
                 self.stdout.write('%s: %.1f%%' % (sample.name, sample.percent))
             self.stdout.write('')
             return
@@ -51,14 +50,14 @@ class Command(BaseCommand):
             raise CommandError('You need to enter a valid percentage value.')
 
         if options['create']:
-            sample, created = Sample.objects.get_or_create(
+            sample, created = get_waffle_sample_model().objects.get_or_create(
                 name=sample_name, defaults={'percent': 0})
             if created:
                 self.stdout.write('Creating sample: %s' % sample_name)
         else:
             try:
-                sample = Sample.objects.get(name=sample_name)
-            except Sample.DoesNotExist:
+                sample = get_waffle_sample_model().objects.get(name=sample_name)
+            except get_waffle_sample_model().DoesNotExist:
                 raise CommandError('This sample does not exist.')
 
         sample.percent = percent

--- a/waffle/management/commands/waffle_switch.py
+++ b/waffle/management/commands/waffle_switch.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentTypeError
 from django.core.management.base import BaseCommand, CommandError
 
-from waffle.models import Switch
+from waffle import get_waffle_switch_model
 
 
 def on_off_bool(string):
@@ -40,7 +40,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options['list_switches']:
             self.stdout.write('Switches:')
-            for switch in Switch.objects.iterator():
+            for switch in get_waffle_switch_model().objects.iterator():
                 self.stdout.write(
                     '%s: %s' % (switch.name, 'on' if switch.active else 'off')
                 )
@@ -53,14 +53,16 @@ class Command(BaseCommand):
         if not (switch_name and state is not None):
             raise CommandError('You need to specify a switch name and state.')
 
-        if options['create']:
-            switch, created = Switch.objects.get_or_create(name=switch_name)
+        if options["create"]:
+            switch, created = get_waffle_switch_model().objects.get_or_create(
+                name=switch_name
+            )
             if created:
                 self.stdout.write('Creating switch: %s' % switch_name)
         else:
             try:
-                switch = Switch.objects.get(name=switch_name)
-            except Switch.DoesNotExist:
+                switch = get_waffle_switch_model().objects.get(name=switch_name)
+            except get_waffle_switch_model().DoesNotExist:
                 raise CommandError('This switch does not exist.')
 
         switch.active = state

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -8,7 +8,12 @@ from django.db import models, router, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from waffle import managers, get_waffle_flag_model
+from waffle import (
+    get_waffle_sample_model,
+    get_waffle_switch_model,
+    get_waffle_flag_model,
+    managers,
+)
 from waffle.utils import get_setting, keyfmt, get_cache
 
 logger = logging.getLogger('waffle')
@@ -460,11 +465,8 @@ class AbstractBaseSwitch(BaseModel):
             if log_level:
                 logger.log(log_level, 'Switch %s not found', self.name)
             if get_setting('CREATE_MISSING_SWITCHES'):
-                switch, _created = Switch.objects.get_or_create(
-                    name=self.name,
-                    defaults={
-                        'active': get_setting('SWITCH_DEFAULT')
-                    }
+                switch, _created = get_waffle_switch_model().objects.get_or_create(
+                    name=self.name, defaults={"active": get_setting("SWITCH_DEFAULT")}
                 )
                 cache = get_cache()
                 cache.set(self._cache_key(self.name), switch)
@@ -531,11 +533,8 @@ class AbstractBaseSample(BaseModel):
 
                 default_percent = 100 if get_setting('SAMPLE_DEFAULT') else 0
 
-                sample, _created = Sample.objects.get_or_create(
-                    name=self.name,
-                    defaults={
-                        'percent': default_percent
-                    }
+                sample, _created = get_waffle_sample_model().objects.get_or_create(
+                    name=self.name, defaults={"percent": default_percent}
                 )
                 cache = get_cache()
                 cache.set(self._cache_key(self.name), sample)

--- a/waffle/tests/test_decorators.py
+++ b/waffle/tests/test_decorators.py
@@ -1,5 +1,4 @@
-from waffle import get_waffle_flag_model
-from waffle.models import Switch
+from waffle import get_waffle_flag_model, get_waffle_switch_model
 from waffle.tests.base import TestCase
 
 
@@ -21,49 +20,49 @@ class DecoratorTests(TestCase):
     def test_switch_must_be_active(self):
         resp = self.client.get('/switch-on')
         self.assertEqual(404, resp.status_code)
-        Switch.objects.create(name='foo', active=True)
+        get_waffle_switch_model().objects.create(name='foo', active=True)
         resp = self.client.get('/switch-on')
         self.assertEqual(200, resp.status_code)
 
     def test_switch_must_be_inactive(self):
         resp = self.client.get('/switch-off')
         self.assertEqual(200, resp.status_code)
-        Switch.objects.create(name='foo', active=True)
+        get_waffle_switch_model().objects.create(name='foo', active=True)
         resp = self.client.get('/switch-off')
         self.assertEqual(404, resp.status_code)
 
     def test_switch_must_be_inactive_and_redirect_to_view(self):
         resp = self.client.get('/switched_view_with_valid_redirect')
         self.assertEqual(302, resp.status_code)
-        Switch.objects.create(name='foo', active=True)
+        get_waffle_switch_model().objects.create(name='foo', active=True)
         resp = self.client.get('/switched_view_with_valid_redirect')
         self.assertEqual(200, resp.status_code)
 
     def test_switch_must_be_inactive_and_redirect_to_named_view(self):
         resp = self.client.get('/switched_view_with_valid_url_name')
         self.assertEqual(302, resp.status_code)
-        Switch.objects.create(name='foo', active=True)
+        get_waffle_switch_model().objects.create(name='foo', active=True)
         resp = self.client.get('/switched_view_with_valid_url_name')
         self.assertEqual(200, resp.status_code)
 
     def test_switch_must_be_inactive_and_redirect_to_view_with_args(self):
         resp = self.client.get('/switched_view_with_args_with_valid_redirect/1/')
         self.assertRedirects(resp, '/foo_view_with_args/1/')
-        Switch.objects.create(name='foo', active=True)
+        get_waffle_switch_model().objects.create(name='foo', active=True)
         resp = self.client.get('/switched_view_with_args_with_valid_redirect/1/')
         self.assertEqual(200, resp.status_code)
 
     def test_switch_must_be_inactive_and_redirect_to_named_view_with_args(self):
         resp = self.client.get('/switched_view_with_args_with_valid_url_name/1/')
         self.assertRedirects(resp, '/foo_view_with_args/1/')
-        Switch.objects.create(name='foo', active=True)
+        get_waffle_switch_model().objects.create(name='foo', active=True)
         resp = self.client.get('/switched_view_with_args_with_valid_url_name/1/')
         self.assertEqual(200, resp.status_code)
 
     def test_switch_must_be_inactive_and_not_redirect(self):
         resp = self.client.get('/switched_view_with_invalid_redirect')
         self.assertEqual(404, resp.status_code)
-        Switch.objects.create(name='foo', active=True)
+        get_waffle_switch_model().objects.create(name='foo', active=True)
         resp = self.client.get('/switched_view_with_invalid_redirect')
         self.assertEqual(200, resp.status_code)
 

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -1,22 +1,31 @@
 from django.test import TestCase
 
-from waffle import get_waffle_flag_model
-from waffle.models import Switch, Sample
+from waffle import (
+    get_waffle_flag_model,
+    get_waffle_sample_model,
+    get_waffle_switch_model,
+)
 
 
 class ModelsTests(TestCase):
     def test_natural_keys(self):
         flag = get_waffle_flag_model().objects.create(name='test-flag')
-        switch = Switch.objects.create(name='test-switch')
-        sample = Sample.objects.create(name='test-sample', percent=0)
+        switch = get_waffle_switch_model().objects.create(name='test-switch')
+        sample = get_waffle_sample_model().objects.create(name='test-sample', percent=0)
 
         self.assertEqual(flag.natural_key(), ('test-flag',))
         self.assertEqual(switch.natural_key(), ('test-switch',))
         self.assertEqual(sample.natural_key(), ('test-sample',))
 
-        self.assertEqual(get_waffle_flag_model().objects.get_by_natural_key('test-flag'), flag)
-        self.assertEqual(Switch.objects.get_by_natural_key('test-switch'), switch)
-        self.assertEqual(Sample.objects.get_by_natural_key('test-sample'), sample)
+        self.assertEqual(
+            get_waffle_flag_model().objects.get_by_natural_key("test-flag"), flag
+        )
+        self.assertEqual(
+            get_waffle_switch_model().objects.get_by_natural_key("test-switch"), switch
+        )
+        self.assertEqual(
+            get_waffle_sample_model().objects.get_by_natural_key("test-sample"), sample
+        )
 
     def test_flag_is_not_active_for_none_requests(self):
         flag = get_waffle_flag_model().objects.create(name='test-flag')

--- a/waffle/tests/test_testutils.py
+++ b/waffle/tests/test_testutils.py
@@ -5,13 +5,12 @@ from django.db import transaction
 from django.test import TransactionTestCase, RequestFactory, TestCase
 
 import waffle
-from waffle.models import Switch, Sample
 from waffle.testutils import override_switch, override_flag, override_sample
 
 
 class OverrideSwitchMixin:
     def test_switch_existed_and_was_active(self):
-        Switch.objects.create(name='foo', active=True)
+        waffle.get_waffle_switch_model().objects.create(name='foo', active=True)
 
         with override_switch('foo', active=True):
             assert waffle.switch_is_active('foo')
@@ -20,10 +19,10 @@ class OverrideSwitchMixin:
             assert not waffle.switch_is_active('foo')
 
         # make sure it didn't change 'active' value
-        assert Switch.objects.get(name='foo').active
+        assert waffle.get_waffle_switch_model().objects.get(name='foo').active
 
     def test_switch_existed_and_was_NOT_active(self):
-        Switch.objects.create(name='foo', active=False)
+        waffle.get_waffle_switch_model().objects.create(name='foo', active=False)
 
         with override_switch('foo', active=True):
             assert waffle.switch_is_active('foo')
@@ -32,10 +31,10 @@ class OverrideSwitchMixin:
             assert not waffle.switch_is_active('foo')
 
         # make sure it didn't change 'active' value
-        assert not Switch.objects.get(name='foo').active
+        assert not waffle.get_waffle_switch_model().objects.get(name='foo').active
 
     def test_new_switch(self):
-        assert not Switch.objects.filter(name='foo').exists()
+        assert not waffle.get_waffle_switch_model().objects.filter(name='foo').exists()
 
         with override_switch('foo', active=True):
             assert waffle.switch_is_active('foo')
@@ -43,10 +42,10 @@ class OverrideSwitchMixin:
         with override_switch('foo', active=False):
             assert not waffle.switch_is_active('foo')
 
-        assert not Switch.objects.filter(name='foo').exists()
+        assert not waffle.get_waffle_switch_model().objects.filter(name='foo').exists()
 
     def test_as_decorator(self):
-        assert not Switch.objects.filter(name='foo').exists()
+        assert not waffle.get_waffle_switch_model().objects.filter(name='foo').exists()
 
         @override_switch('foo', active=True)
         def test_enabled():
@@ -60,10 +59,10 @@ class OverrideSwitchMixin:
 
         test_disabled()
 
-        assert not Switch.objects.filter(name='foo').exists()
+        assert not waffle.get_waffle_switch_model().objects.filter(name='foo').exists()
 
     def test_restores_after_exception(self):
-        Switch.objects.create(name='foo', active=True)
+        waffle.get_waffle_switch_model().objects.create(name='foo', active=True)
 
         def inner():
             with override_switch('foo', active=False):
@@ -72,10 +71,10 @@ class OverrideSwitchMixin:
         with self.assertRaises(RuntimeError):
             inner()
 
-        assert Switch.objects.get(name='foo').active
+        assert waffle.get_waffle_switch_model().objects.get(name='foo').active
 
     def test_restores_after_exception_in_decorator(self):
-        Switch.objects.create(name='foo', active=True)
+        waffle.get_waffle_switch_model().objects.create(name='foo', active=True)
 
         @override_switch('foo', active=False)
         def inner():
@@ -84,10 +83,10 @@ class OverrideSwitchMixin:
         with self.assertRaises(RuntimeError):
             inner()
 
-        assert Switch.objects.get(name='foo').active
+        assert waffle.get_waffle_switch_model().objects.get(name='foo').active
 
     def test_cache_is_flushed_by_testutils_even_in_transaction(self):
-        Switch.objects.create(name='foo', active=True)
+        waffle.get_waffle_switch_model().objects.create(name='foo', active=True)
 
         with transaction.atomic():
             with override_switch('foo', active=True):
@@ -189,7 +188,7 @@ class OverrideFlagsTransactionTestCase(OverrideFlagTestsMixin, TransactionTestCa
 
 class OverrideSampleTestsMixin:
     def test_sample_existed_and_was_100(self):
-        Sample.objects.create(name='foo', percent='100.0')
+        waffle.get_waffle_sample_model().objects.create(name='foo', percent='100.0')
 
         with override_sample('foo', active=True):
             assert waffle.sample_is_active('foo')
@@ -198,10 +197,10 @@ class OverrideSampleTestsMixin:
             assert not waffle.sample_is_active('foo')
 
         self.assertEqual(Decimal('100.0'),
-                          Sample.objects.get(name='foo').percent)
+                          waffle.get_waffle_sample_model().objects.get(name='foo').percent)
 
     def test_sample_existed_and_was_0(self):
-        Sample.objects.create(name='foo', percent='0.0')
+        waffle.get_waffle_sample_model().objects.create(name='foo', percent='0.0')
 
         with override_sample('foo', active=True):
             assert waffle.sample_is_active('foo')
@@ -210,10 +209,10 @@ class OverrideSampleTestsMixin:
             assert not waffle.sample_is_active('foo')
 
         self.assertEqual(Decimal('0.0'),
-                          Sample.objects.get(name='foo').percent)
+                          waffle.get_waffle_sample_model().objects.get(name='foo').percent)
 
     def test_sample_existed_and_was_50(self):
-        Sample.objects.create(name='foo', percent='50.0')
+        waffle.get_waffle_sample_model().objects.create(name='foo', percent='50.0')
 
         with override_sample('foo', active=True):
             assert waffle.sample_is_active('foo')
@@ -222,10 +221,10 @@ class OverrideSampleTestsMixin:
             assert not waffle.sample_is_active('foo')
 
         self.assertEqual(Decimal('50.0'),
-                          Sample.objects.get(name='foo').percent)
+                          waffle.get_waffle_sample_model().objects.get(name='foo').percent)
 
     def test_sample_did_not_exist(self):
-        assert not Sample.objects.filter(name='foo').exists()
+        assert not waffle.get_waffle_sample_model().objects.filter(name='foo').exists()
 
         with override_sample('foo', active=True):
             assert waffle.sample_is_active('foo')
@@ -233,10 +232,10 @@ class OverrideSampleTestsMixin:
         with override_sample('foo', active=False):
             assert not waffle.sample_is_active('foo')
 
-        assert not Sample.objects.filter(name='foo').exists()
+        assert not waffle.get_waffle_sample_model().objects.filter(name='foo').exists()
 
     def test_cache_is_flushed_by_testutils_even_in_transaction(self):
-        Sample.objects.create(name='foo', percent='100.0')
+        waffle.get_waffle_sample_model().objects.create(name='foo', percent='100.0')
 
         with transaction.atomic():
             with override_sample('foo', active=True):
@@ -264,8 +263,8 @@ class OverrideSwitchOnClassTestsMixin(object):
     @classmethod
     def setUpClass(cls):
         super(OverrideSwitchOnClassTestsMixin, cls).setUpClass()
-        assert not Switch.objects.filter(name='foo').exists()
-        Switch.objects.create(name='foo', active=True)
+        assert not waffle.get_waffle_switch_model().objects.filter(name='foo').exists()
+        waffle.get_waffle_switch_model().objects.create(name='foo', active=True)
 
     def test_undecorated_method_is_set_properly_for_switch(self):
         self.assertFalse(waffle.switch_is_active('foo'))
@@ -318,8 +317,8 @@ class OverrideSampleOnClassTestsMixin(object):
     @classmethod
     def setUpClass(cls):
         super(OverrideSampleOnClassTestsMixin, cls).setUpClass()
-        assert not Sample.objects.filter(name='foo').exists()
-        Sample.objects.create(name='foo', percent='100.0')
+        assert not waffle.get_waffle_sample_model().objects.filter(name='foo').exists()
+        waffle.get_waffle_sample_model().objects.create(name='foo', percent='100.0')
 
     def test_undecorated_method_is_set_properly_for_sample(self):
         self.assertFalse(waffle.sample_is_active('foo'))

--- a/waffle/tests/test_views.py
+++ b/waffle/tests/test_views.py
@@ -1,7 +1,10 @@
 from django.urls import reverse
 
-from waffle import get_waffle_flag_model, get_waffle_sample_model, get_waffle_switch_model
-from waffle.models import Sample, Switch
+from waffle import (
+    get_waffle_flag_model,
+    get_waffle_sample_model,
+    get_waffle_switch_model,
+)
 from waffle.tests.base import TestCase
 
 
@@ -63,7 +66,7 @@ class WaffleViewTests(TestCase):
 
     def test_flush_all_switches(self):
         """Test the 'SWITCHES_ALL' list gets invalidated correctly."""
-        switch = Switch.objects.create(name='myswitch', active=True)
+        switch = get_waffle_switch_model().objects.create(name='myswitch', active=True)
         response = self.client.get(reverse('wafflejs'))
         self.assertEqual(200, response.status_code)
         assert ('myswitch', True) in response.context['switches']
@@ -76,12 +79,12 @@ class WaffleViewTests(TestCase):
 
     def test_flush_all_samples(self):
         """Test the 'SAMPLES_ALL' list gets invalidated correctly."""
-        Sample.objects.create(name='sample1', percent='100.0')
+        get_waffle_sample_model().objects.create(name='sample1', percent='100.0')
         response = self.client.get(reverse('wafflejs'))
         self.assertEqual(200, response.status_code)
         assert ('sample1', True) in response.context['samples']
 
-        Sample.objects.create(name='sample2', percent='100.0')
+        get_waffle_sample_model().objects.create(name='sample2', percent='100.0')
 
         response = self.client.get(reverse('wafflejs'))
         self.assertEqual(200, response.status_code)

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -1,6 +1,10 @@
 from django.test.utils import TestContextDecorator
 
-from waffle import get_waffle_flag_model
+from waffle import (
+    get_waffle_flag_model,
+    get_waffle_sample_model,
+    get_waffle_switch_model,
+)
 from waffle.models import Switch, Sample
 
 
@@ -58,7 +62,7 @@ class override_switch(_overrider):
             ...
 
     """
-    cls = Switch
+    cls = get_waffle_switch_model()
 
     def update(self, active):
         obj = self.cls.objects.get(pk=self.obj.pk)
@@ -84,7 +88,7 @@ class override_flag(_overrider):
 
 
 class override_sample(_overrider):
-    cls = Sample
+    cls = get_waffle_sample_model()
 
     def get(self):
         try:


### PR DESCRIPTION
Remove direct references to `Switch` and `Sample` in favor of
`get_waffle_switch_model` and `get_waffle_sample_model`.