### PR TITLE
Add python_requires and install_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(
     include_package_data=True,
     package_data={'': ['README.rst']},
     zip_safe=False,
+    python_requires='>=3.7',
+    install_requires=['django>=3.2'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
Without `python_requires`, pip will let you install django-waffle 3.0 on python 3.6 and lower, which are now unsupported. And django-waffle should depend on django, because based on the name of the project, it does, so adding `install_requires` to reflect that.