### PR TITLE
misc: Add more type hints

### DIFF
--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -1,7 +1,10 @@
+from typing import Any, Dict, Tuple
+
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry, CHANGE, DELETION
 from django.contrib.admin.widgets import ManyToManyRawIdWidget
 from django.contrib.contenttypes.models import ContentType
+from django.http import HttpRequest
 from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
 
@@ -12,7 +15,7 @@ from waffle.utils import get_setting
 class BaseAdmin(admin.ModelAdmin):
     search_fields = ('name', 'note')
 
-    def get_actions(self, request):
+    def get_actions(self, request: HttpRequest) -> Dict[str, Any]:
         actions = super().get_actions(request)
         if 'delete_selected' in actions:
             del actions['delete_selected']
@@ -70,7 +73,7 @@ class InformativeManyToManyRawIdWidget(ManyToManyRawIdWidget):
     Will display the names of the users in a parenthesised list after the
     input field. This widget works with all models that have a "name" field.
     """
-    def label_and_url_for_value(self, values):
+    def label_and_url_for_value(self, values: Any) -> Tuple[str, str]:
         names = []
         key = self.rel.get_related_field().name
         for value in values:

--- a/waffle/decorators.py
+++ b/waffle/decorators.py
@@ -1,14 +1,17 @@
 from functools import wraps, WRAPPER_ASSIGNMENTS
+from typing import Any, Callable, Optional, Union
 
-from django.http import Http404
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse, NoReverseMatch
 
 from waffle import flag_is_active, switch_is_active
 
 
-def waffle_flag(flag_name, redirect_to=None):
-    def decorator(view):
+def waffle_flag(
+    flag_name: str, redirect_to: Optional[Union[Callable, str]] = None,
+) -> Callable[[Callable[[HttpRequest], HttpResponse]], Callable[[HttpRequest], HttpResponse]]:
+    def decorator(view: Callable[[HttpRequest], HttpResponse]) -> Callable[[HttpRequest], HttpResponse]:
         @wraps(view, assigned=WRAPPER_ASSIGNMENTS)
         def _wrapped_view(request, *args, **kwargs):
             if flag_name.startswith('!'):
@@ -28,8 +31,10 @@ def waffle_flag(flag_name, redirect_to=None):
     return decorator
 
 
-def waffle_switch(switch_name, redirect_to=None):
-    def decorator(view):
+def waffle_switch(
+    switch_name: str, redirect_to: Optional[Union[Callable, str]] = None,
+) -> Callable[[Callable[[HttpRequest], HttpResponse]], Callable[[HttpRequest], HttpResponse]]:
+    def decorator(view: Callable[[HttpRequest], HttpResponse]) -> Callable[[HttpRequest], HttpResponse]:
         @wraps(view, assigned=WRAPPER_ASSIGNMENTS)
         def _wrapped_view(request, *args, **kwargs):
             if switch_name.startswith('!'):
@@ -49,7 +54,9 @@ def waffle_switch(switch_name, redirect_to=None):
     return decorator
 
 
-def get_response_to_redirect(view, *args, **kwargs):
+def get_response_to_redirect(
+    view: Optional[Union[Callable, str]], *args: Any, **kwargs: Any,
+) -> Optional[Union[HttpResponseRedirect, HttpResponsePermanentRedirect]]:
     try:
         return redirect(reverse(view, args=args, kwargs=kwargs)) if view else None
     except NoReverseMatch:

--- a/waffle/management/commands/waffle_switch.py
+++ b/waffle/management/commands/waffle_switch.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand, CommandError, CommandParser
 from waffle import get_waffle_switch_model
 
 
-def on_off_bool(string):
+def on_off_bool(string: str) -> bool:
     if string not in ['on', 'off']:
         raise ArgumentTypeError("invalid choice: %r (choose from 'on', "
                                 "'off')" % string)

--- a/waffle/managers.py
+++ b/waffle/managers.py
@@ -1,15 +1,23 @@
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
 from django.db import models
 
 from waffle.utils import get_setting, get_cache
 
 
-class BaseManager(models.Manager):
+if TYPE_CHECKING:
+    from waffle.models import _BaseModelType, AbstractBaseFlag, AbstractBaseSample, AbstractBaseSwitch
+else:
+    _BaseModelType = TypeVar("_BaseModelType")
+
+
+class BaseManager(models.Manager, Generic[_BaseModelType]):
     KEY_SETTING = ''
 
-    def get_by_natural_key(self, name):
+    def get_by_natural_key(self, name: str) -> _BaseModelType:
         return self.get(name=name)
 
-    def create(self, *args, **kwargs):
+    def create(self, *args: Any, **kwargs: Any) -> _BaseModelType:
         cache = get_cache()
         ret = super().create(*args, **kwargs)
         cache_key = get_setting(self.KEY_SETTING)
@@ -17,13 +25,13 @@ class BaseManager(models.Manager):
         return ret
 
 
-class FlagManager(BaseManager):
+class FlagManager(BaseManager['AbstractBaseFlag']):
     KEY_SETTING = 'ALL_FLAGS_CACHE_KEY'
 
 
-class SwitchManager(BaseManager):
+class SwitchManager(BaseManager['AbstractBaseSwitch']):
     KEY_SETTING = 'ALL_SWITCHES_CACHE_KEY'
 
 
-class SampleManager(BaseManager):
+class SampleManager(BaseManager['AbstractBaseSample']):
     KEY_SETTING = 'ALL_SAMPLES_CACHE_KEY'

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from decimal import Decimal
-from typing import Any, List, Optional, Set, Tuple, Type, TypeVar
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, Group
@@ -102,7 +102,7 @@ class BaseModel(models.Model):
         ]
         cache.delete_many(keys)
 
-    def save(self, *args, **kwargs):
+    def save(self, *args: Any, **kwargs: Any) -> None:
         self.modified = timezone.now()
         ret = super().save(*args, **kwargs)
         if hasattr(transaction, 'on_commit'):
@@ -111,7 +111,7 @@ class BaseModel(models.Model):
             self.flush()
         return ret
 
-    def delete(self, *args, **kwargs):
+    def delete(self, *args: Any, **kwargs: Any) -> Tuple[int, Dict[str, int]]:
         ret = super().delete(*args, **kwargs)
         if hasattr(transaction, 'on_commit'):
             transaction.on_commit(self.flush)

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -1,4 +1,6 @@
-from django.http import HttpResponse, JsonResponse
+from typing import Any, Dict
+
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.template import loader
 from django.views.decorators.cache import never_cache
 
@@ -12,7 +14,7 @@ def wafflejs(request):
                         content_type='application/x-javascript')
 
 
-def _generate_waffle_js(request):
+def _generate_waffle_js(request: HttpRequest) -> str:
     flags = get_waffle_flag_model().get_all()
     flag_values = [(f.name, f.is_active(request)) for f in flags]
 
@@ -37,7 +39,7 @@ def waffle_json(request):
     return JsonResponse(_generate_waffle_json(request))
 
 
-def _generate_waffle_json(request):
+def _generate_waffle_json(request: HttpRequest) -> Dict[str, Dict[str, Any]]:
     flags = get_waffle_flag_model().get_all()
     flag_values = {
         f.name: {


### PR DESCRIPTION
Adding more missing type hints to the project, mainly for:
* Decorators,
* Models and managers,
* Testutils `override_*` context managers.