### PR TITLE
misc: Distribute and package type information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['test_app', 'test_settings']),
     include_package_data=True,
-    package_data={'': ['README.rst']},
+    package_data={
+        '': ['README.rst'],
+        'waffle': ['py.typed'],
+    },
     zip_safe=False,
     python_requires='>=3.7',
     install_requires=['django>=3.2'],


### PR DESCRIPTION
According to [PEP 561](https://peps.python.org/pep-0561/), these should be the only required changes for this project to start distribution the type hints, for dependant applications to benefit from.