### PR TITLE
mock was moved into the Python Standard Library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ django-jinja>=2.4.1,<3
 transifex-client
 
 flake8
-mock==1.3.0
 mypy
 tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,2 @@
 flake8
-mock==4.0.3
 tox


### PR DESCRIPTION
Since Python 3.3... https://docs.python.org/3/library/unittest.mock.html