### PR TITLE
from __future__ import annotations

### DIFF
--- a/waffle/__init__.py
+++ b/waffle/__init__.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Optional, Type, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import django
 from django.core.exceptions import ImproperlyConfigured
@@ -14,7 +16,7 @@ VERSION = (3, 0, 0)
 __version__ = '.'.join(map(str, VERSION))
 
 
-def flag_is_active(request: HttpRequest, flag_name: str, read_only: bool = False) -> Optional[bool]:
+def flag_is_active(request: HttpRequest, flag_name: str, read_only: bool = False) -> bool | None:
     flag = get_waffle_flag_model().get(flag_name)
     return flag.is_active(request, read_only=read_only)
 
@@ -29,21 +31,21 @@ def sample_is_active(sample_name: str) -> bool:
     return sample.is_active()
 
 
-def get_waffle_flag_model() -> Type['AbstractBaseFlag']:
+def get_waffle_flag_model() -> type[AbstractBaseFlag]:
     return get_waffle_model('FLAG_MODEL')
 
 
-def get_waffle_switch_model() -> Type['AbstractBaseSwitch']:
+def get_waffle_switch_model() -> type[AbstractBaseSwitch]:
     return get_waffle_model('SWITCH_MODEL')
 
 
-def get_waffle_sample_model() -> Type['AbstractBaseSample']:
+def get_waffle_sample_model() -> type[AbstractBaseSample]:
     return get_waffle_model('SAMPLE_MODEL')
 
 
-def get_waffle_model(setting_name: str) -> Union[
-    Type['AbstractBaseFlag'], Type['AbstractBaseSwitch'], Type['AbstractBaseSample']
-]:
+def get_waffle_model(setting_name: str) -> (
+    type[AbstractBaseFlag] | type[AbstractBaseSwitch] | type[AbstractBaseSample]
+):
     """
     Returns the waffle Flag model that is active in this project.
     """

--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Tuple
+from __future__ import annotations
+
+from typing import Any
 
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry, CHANGE, DELETION
@@ -15,7 +17,7 @@ from waffle.utils import get_setting
 class BaseAdmin(admin.ModelAdmin):
     search_fields = ('name', 'note')
 
-    def get_actions(self, request: HttpRequest) -> Dict[str, Any]:
+    def get_actions(self, request: HttpRequest) -> dict[str, Any]:
         actions = super().get_actions(request)
         if 'delete_selected' in actions:
             del actions['delete_selected']
@@ -73,7 +75,7 @@ class InformativeManyToManyRawIdWidget(ManyToManyRawIdWidget):
     Will display the names of the users in a parenthesised list after the
     input field. This widget works with all models that have a "name" field.
     """
-    def label_and_url_for_value(self, values: Any) -> Tuple[str, str]:
+    def label_and_url_for_value(self, values: Any) -> tuple[str, str]:
         names = []
         key = self.rel.get_related_field().name
         for value in values:

--- a/waffle/decorators.py
+++ b/waffle/decorators.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import wraps, WRAPPER_ASSIGNMENTS
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.shortcuts import redirect
@@ -9,7 +11,7 @@ from waffle import flag_is_active, switch_is_active
 
 
 def waffle_flag(
-    flag_name: str, redirect_to: Optional[Union[Callable, str]] = None,
+    flag_name: str, redirect_to: Callable | str | None = None,
 ) -> Callable[[Callable[[HttpRequest], HttpResponse]], Callable[[HttpRequest], HttpResponse]]:
     def decorator(view: Callable[[HttpRequest], HttpResponse]) -> Callable[[HttpRequest], HttpResponse]:
         @wraps(view, assigned=WRAPPER_ASSIGNMENTS)
@@ -32,7 +34,7 @@ def waffle_flag(
 
 
 def waffle_switch(
-    switch_name: str, redirect_to: Optional[Union[Callable, str]] = None,
+    switch_name: str, redirect_to: Callable | str | None = None,
 ) -> Callable[[Callable[[HttpRequest], HttpResponse]], Callable[[HttpRequest], HttpResponse]]:
     def decorator(view: Callable[[HttpRequest], HttpResponse]) -> Callable[[HttpRequest], HttpResponse]:
         @wraps(view, assigned=WRAPPER_ASSIGNMENTS)
@@ -55,8 +57,8 @@ def waffle_switch(
 
 
 def get_response_to_redirect(
-    view: Optional[Union[Callable, str]], *args: Any, **kwargs: Any,
-) -> Optional[Union[HttpResponseRedirect, HttpResponsePermanentRedirect]]:
+    view: Callable | str | None, *args: Any, **kwargs: Any,
+) -> HttpResponseRedirect | HttpResponsePermanentRedirect | None:
     try:
         return redirect(reverse(view, args=args, kwargs=kwargs)) if view else None
     except NoReverseMatch:

--- a/waffle/mixins.py
+++ b/waffle/mixins.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from functools import partial
-from typing import Optional
 
 from django.http import Http404
 
@@ -25,7 +26,7 @@ class WaffleFlagMixin(BaseWaffleMixin):
     waffle_flag
     """
 
-    waffle_flag: Optional[str] = None
+    waffle_flag: str | None = None
 
     def dispatch(self, request, *args, **kwargs):
         func = partial(flag_is_active, request)
@@ -43,7 +44,7 @@ class WaffleSampleMixin(BaseWaffleMixin):
     waffle_sample.
     """
 
-    waffle_sample: Optional[str] = None
+    waffle_sample: str | None = None
 
     def dispatch(self, request, *args, **kwargs):
         active = self.validate_waffle(self.waffle_sample, sample_is_active)
@@ -60,7 +61,7 @@ class WaffleSwitchMixin(BaseWaffleMixin):
     waffle_switch.
     """
 
-    waffle_switch: Optional[str] = None
+    waffle_switch: str | None = None
 
     def dispatch(self, request, *args, **kwargs):
         active = self.validate_waffle(self.waffle_switch, switch_is_active)

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -81,13 +81,13 @@ class override_switch(_overrider[bool]):
 class override_flag(_overrider[Optional[bool]]):
     cls = get_waffle_flag_model()
 
-    def update(self, active: Optional[bool]) -> None:
+    def update(self, active: bool | None) -> None:
         obj = self.cls.objects.get(pk=self.obj.pk)
         obj.everyone = active
         obj.save()
         obj.flush()
 
-    def get_value(self) -> Optional[bool]:
+    def get_value(self) -> bool | None:
         return self.obj.everyone
 
 
@@ -102,7 +102,7 @@ class override_sample(_overrider[Union[bool, float]]):
             self.obj = self.cls.objects.create(name=self.name, percent='0.0')
             self.created = True
 
-    def update(self, active: Union[bool, float]) -> None:
+    def update(self, active: bool | float) -> None:
         if active is True:
             p = 100.0
         elif active is False:
@@ -114,7 +114,7 @@ class override_sample(_overrider[Union[bool, float]]):
         obj.save()
         obj.flush()
 
-    def get_value(self) -> Union[bool, float]:
+    def get_value(self) -> bool | float:
         p = self.obj.percent
         if p == 100.0:
             return True

--- a/waffle/testutils.py
+++ b/waffle/testutils.py
@@ -81,13 +81,13 @@ class override_switch(_overrider[bool]):
 class override_flag(_overrider[Optional[bool]]):
     cls = get_waffle_flag_model()
 
-    def update(self, active: bool | None) -> None:
+    def update(self, active: Optional[bool]) -> None:
         obj = self.cls.objects.get(pk=self.obj.pk)
         obj.everyone = active
         obj.save()
         obj.flush()
 
-    def get_value(self) -> bool | None:
+    def get_value(self) -> Optional[bool]:
         return self.obj.everyone
 
 
@@ -102,7 +102,7 @@ class override_sample(_overrider[Union[bool, float]]):
             self.obj = self.cls.objects.create(name=self.name, percent='0.0')
             self.created = True
 
-    def update(self, active: bool | float) -> None:
+    def update(self, active: Union[bool, float]) -> None:
         if active is True:
             p = 100.0
         elif active is False:
@@ -114,7 +114,7 @@ class override_sample(_overrider[Union[bool, float]]):
         obj.save()
         obj.flush()
 
-    def get_value(self) -> bool | float:
+    def get_value(self) -> Union[bool, float]:
         p = self.obj.percent
         if p == 100.0:
             return True

--- a/waffle/utils.py
+++ b/waffle/utils.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import hashlib
-from typing import Any, Optional
+from typing import Any
 
 from django.conf import settings
 from django.core.cache import BaseCache, caches
@@ -15,7 +17,7 @@ def get_setting(name: str, default: Any = None) -> Any:
         return getattr(defaults, name, default)
 
 
-def keyfmt(k: str, v: Optional[str] = None) -> str:
+def keyfmt(k: str, v: str | None = None) -> str:
     prefix = get_setting('CACHE_PREFIX') + waffle.__version__
     if v is None:
         key = prefix + k

--- a/waffle/views.py
+++ b/waffle/views.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.template import loader
@@ -39,7 +41,7 @@ def waffle_json(request):
     return JsonResponse(_generate_waffle_json(request))
 
 
-def _generate_waffle_json(request: HttpRequest) -> Dict[str, Dict[str, Any]]:
+def _generate_waffle_json(request: HttpRequest) -> dict[str, dict[str, Any]]:
     flags = get_waffle_flag_model().get_all()
     flag_values = {
         f.name: {


### PR DESCRIPTION
Simplify Python typing by adding [`from __future__ import annotations`](https://docs.python.org/3/library/__future__.html) and running [`pyupgrade --py37-plus **/*.py`](https://github.com/asottile/pyupgrade#pep-585-typing-rewrites)