### PR TITLE
Typos: codespell --skip="*.po" -w

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,7 +52,7 @@ and squashed into a minimal set of commits. Each commit should include
 the necessary code, test, and documentation changes for a single "piece"
 of functionality.
 
-To be mergable, patches must:
+To be mergeable, patches must:
 
 - be rebased onto the latest master,
 - be automatically mergeable,

--- a/docs/about/contributing.rst
+++ b/docs/about/contributing.rst
@@ -52,7 +52,7 @@ and squashed into a minimal set of commits. Each commit should include
 the necessary code, test, and documentation changes for a single "piece"
 of functionality.
 
-To be mergable, patches must:
+To be mergeable, patches must:
 
 - be rebased onto the latest master,
 - be automatically mergeable,

--- a/docs/usage/json.rst
+++ b/docs/usage/json.rst
@@ -9,7 +9,7 @@ Although :doc:`WaffleJS<javascript>` returns the status of all
 :ref:`samples <types-sample>`, it does so by exposing a Javascript
 object, rather than returning the data in a directly consumable format.
 
-In cases where a directly consumable format is preferrable,
+In cases where a directly consumable format is preferable,
 Waffle also exposes this data as JSON via the ``waffle_status`` view.
 
 


### PR DESCRIPTION
[`codespell --skip="*.po" -w`](https://pypi.org/project/codespell)