### PR TITLE
Django 4.2.0 and Python 3.11 compatibility

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10', '3.11' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py{37,38,39,310}-django{32}
-    py{38,39,310}-django{40,41}
+    py{38,39,310}-django{40,41,42}
+    py{311}-django{41,42}
 isolated_build = True
 
 [gh-actions]
@@ -10,6 +11,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 allowlist_externals = ./run.sh
@@ -17,6 +19,7 @@ deps =
 	django32: Django>=3.2,<3.3
 	django40: Django>=4.0,<4.1
 	django41: Django>=4.1,<4.2
+	django42: Django>=4.2,<4.3
 	djangomain: https://github.com/django/django/archive/main.tar.gz
 	-r{toxinidir}/requirements.txt
 commands =
@@ -33,7 +36,7 @@ commands =
 
 [testenv:typecheck]
 deps =
-	Django>=3.2,<4.2
+	Django>=3.2,<4.3
 	-r{toxinidir}/requirements.txt
 commands =
     ./run.sh typecheck

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ python =
     3.10: py310
 
 [testenv]
+allowlist_externals = ./run.sh
 deps =
 	django32: Django>=3.2,<3.3
 	django40: Django>=4.0,<4.1


### PR DESCRIPTION
This PR doesn't change any of the underlying library code, it just runs the tests against Django 4.2 and Python 3.11 (for supported Django versions, 4.1 and 4.2).

The [commit adding `run.sh` to `allowlist_externals`](1f18fcd82b215975fec8fb05c70fffe5af8b7b40) was required to get the tests running under `tox` and given that it's something I've had to implement before figured it was probably important enough to include. Though it is surprising that it's not been an issue for anyone else... 

This should presumably be enough to close #483 and #411