### PR TITLE
add support for everyone option to is_active_for_user

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -230,6 +230,9 @@ class AbstractBaseFlag(BaseModel):
         return flush_keys
 
     def is_active_for_user(self, user: AbstractBaseUser) -> bool | None:
+        if self.everyone:
+            return True
+
         if self.authenticated and user.is_authenticated:
             return True
 

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -5,6 +5,7 @@ from waffle import (
     get_waffle_sample_model,
     get_waffle_switch_model,
 )
+from django.contrib.auth.models import User
 
 
 class ModelsTests(TestCase):
@@ -30,3 +31,8 @@ class ModelsTests(TestCase):
     def test_flag_is_not_active_for_none_requests(self):
         flag = get_waffle_flag_model().objects.create(name='test-flag')
         self.assertEqual(flag.is_active(None), False)
+
+    def test_is_active_for_user_when_everyone_is_active(self):
+        flag = get_waffle_flag_model().objects.create(name='test-flag')
+        flag.everyone = True
+        self.assertEqual(flag.is_active_for_user(User()), True)


### PR DESCRIPTION
fixes #401 

This adds support of the `everyone` boolean to `is_active_for_user`