### PR TITLE
Add --testing option to waffle_flag mgmt command

### DIFF
--- a/waffle/management/commands/waffle_flag.py
+++ b/waffle/management/commands/waffle_flag.py
@@ -84,6 +84,13 @@ class Command(BaseCommand):
             default=False,
             help='Turn on rollout mode.')
         parser.add_argument(
+            '--testing', '-t',
+            action='store_true',
+            dest='testing',
+            default=False,
+            help='Turn on testing mode, allowing the flag to be specified via '
+                 'a querystring parameter.')
+        parser.add_argument(
             '--create',
             action='store_true',
             dest='create',

--- a/waffle/tests/test_management.py
+++ b/waffle/tests/test_management.py
@@ -17,13 +17,14 @@ class WaffleFlagManagementCommandTests(TestCase):
         name = 'test'
         percent = 20
         Group.objects.create(name='waffle_group')
-        call_command('waffle_flag', name, percent=percent,
+        call_command('waffle_flag', name, percent=percent, testing=True,
                      superusers=True, staff=True, authenticated=True,
                      rollout=True, create=True, group=['waffle_group'])
 
         flag = get_waffle_flag_model().objects.get(name=name)
         self.assertEqual(flag.percent, percent)
         self.assertIsNone(flag.everyone)
+        self.assertTrue(flag.testing)
         self.assertTrue(flag.superusers)
         self.assertTrue(flag.staff)
         self.assertTrue(flag.authenticated)


### PR DESCRIPTION
Noticed a little while back that the `waffle_flag` management command doesn't seem to have ever supported an option for "testing" mode.  This PR adds it as the `--testing` / `-t` option, and updates `test_management.py:WaffleFlagManagementCommandTests.test_create` verifying that the option can get set correctly.