### PR TITLE
Make is_active_for_user consider when everyone is False

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -233,6 +233,9 @@ class AbstractBaseFlag(BaseModel):
         if self.everyone:
             return True
 
+        if self.everyone is False:
+            return False
+
         if self.authenticated and user.is_authenticated:
             return True
 
@@ -396,7 +399,8 @@ class AbstractUserFlag(AbstractBaseFlag):
 
     def is_active_for_user(self, user: AbstractBaseUser) -> bool | None:
         is_active = super().is_active_for_user(user)
-        if is_active:
+
+        if is_active is True or is_active is False:
             return is_active
 
         user_ids = self._get_user_ids()

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from waffle import (
@@ -5,8 +6,6 @@ from waffle import (
     get_waffle_sample_model,
     get_waffle_switch_model,
 )
-from django.contrib.auth.models import User
-
 
 class ModelsTests(TestCase):
     def test_natural_keys(self):
@@ -33,6 +32,13 @@ class ModelsTests(TestCase):
         self.assertEqual(flag.is_active(None), False)
 
     def test_is_active_for_user_when_everyone_is_active(self):
+        user = get_user_model()(username='john.doe')
         flag = get_waffle_flag_model().objects.create(name='test-flag')
         flag.everyone = True
-        self.assertEqual(flag.is_active_for_user(User()), True)
+        self.assertEqual(flag.is_active_for_user(user), True)
+
+    def test_is_active_for_user_when_everyone_is_disabled(self):
+        user = get_user_model()(username='john.doe')
+        flag = get_waffle_flag_model().objects.create(name='test-flag')
+        flag.everyone = False
+        self.assertEqual(flag.is_active_for_user(user), False)


### PR DESCRIPTION
This adds a check to the `is_active_for_user` method to consider when the attribute `everyone` is False.

Fixes #401