### PR TITLE
Add flake8 to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,6 @@
-repos: []
+files: ^waffle/
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '7.0.0'
+    hooks:
+    -   id: flake8


### PR DESCRIPTION
We only check the waffle directory to keep it equivalent to the existing linter.