### PR TITLE
Create dependabot config for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Coming here from https://github.com/jazzband/django-waffle/pull/511 . I didn't want to apply actions updates by hand when they can be automatized, so there is the dependabot config. After the merge, triggering the updates will create an update PR automatically.