### PR TITLE
Delete setup.cfg which only contains flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[flake8]
-extend-ignore =
-    # break before binary operators
-    W503,
-    # line length
-    E501


### PR DESCRIPTION
`flake8` was removed in:
* #518