### PR TITLE
Add Read the docs status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,10 @@ a number of ways.
 .. image:: https://badge.fury.io/py/django-waffle.svg
    :target: https://badge.fury.io/py/django-waffle
    :alt: PyPI status badge
+.. image:: https://img.shields.io/readthedocs/waffle
+   :target: https://app.readthedocs.org/projects/waffle
+   :alt: Read the Docs
+
 
 :Code:          https://github.com/jazzband/django-waffle
 :License:       BSD; see LICENSE file


### PR DESCRIPTION
The documentation build was broken for many months this year but this was not immediately visible anywhere on the GitHub repo. I propose to add a read the docs status badge rather than an actions status badge as this is a better source of truth about the documentation build status.

Tested visually when committing - the badge and link both work :)