### PR TITLE
Fixes test suite for django v5x (#555)

### DIFF
--- a/waffle/tests/base.py
+++ b/waffle/tests/base.py
@@ -4,9 +4,9 @@ from django.core import cache
 
 class TestCase(test.TransactionTestCase):
 
-    def _pre_setup(self):
+    def setUp(self):
         cache.cache.clear()
-        super()._pre_setup()
+        super().setUp()
 
 
 class ReplicationRouter:

--- a/waffle/tests/test_admin.py
+++ b/waffle/tests/test_admin.py
@@ -38,6 +38,7 @@ skip_if_admin_permissions_not_available = \
 
 class FlagAdminTests(TestCase):
     def setUp(self):
+        super().setUp()
         self.site = AdminSite()
         self.flag_admin = FlagAdmin(Flag, self.site)
 
@@ -124,6 +125,7 @@ class FlagAdminTests(TestCase):
 
 class SwitchAdminTests(TestCase):
     def setUp(self):
+        super().setUp()
         self.site = AdminSite()
         self.switch_admin = SwitchAdmin(Switch, self.site)
 

--- a/waffle/tests/test_mixin.py
+++ b/waffle/tests/test_mixin.py
@@ -25,6 +25,7 @@ def process_request(request, view):
 
 class WaffleFlagMixinTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.request = get()
 
     def test_flag_must_be_active(self):
@@ -54,6 +55,7 @@ class WaffleFlagMixinTest(TestCase):
 
 class WaffleSampleMixinTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.request = get()
 
     def test_sample_must_be_active(self):
@@ -81,6 +83,7 @@ class WaffleSampleMixinTest(TestCase):
 
 class WaffleSwitchMixinTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.request = get()
 
     def test_switch_must_be_active(self):


### PR DESCRIPTION
Use of internal `_pre_setup` test method caused broken test suite on newer version of django. This PR uses standard `setUp` method instead. Was tested on django 4.2. and 5.2.

Because of this issue test for the following PRs are failing:
- https://github.com/jazzband/django-waffle/pull/554
- https://github.com/jazzband/django-waffle/pull/552
- https://github.com/jazzband/django-waffle/pull/545