### PR TITLE
Fixing the issue of everyone setting not being taken into account by flag.is_actvive_for_user method.

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -230,8 +230,9 @@ class AbstractBaseFlag(BaseModel):
         return flush_keys
 
     def is_active_for_user(self, user: AbstractBaseUser) -> bool | None:
-        if self.everyone:
-            return True
+        # According to the docs, everyone should override all the other settings
+        if self.everyone is not None:
+            return self.everyone
 
         if self.authenticated and user.is_authenticated:
             return True

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -803,3 +803,39 @@ class FunctionTests(TestCase):
         response = process_request(request, views.flag_in_view_readonly)
         assert 'dwf_myflag' not in response.cookies
         self.assertEqual(b'off', response.content)
+
+
+class WaffleFlagEveryoneSettingTests(TestCase):
+    databases = DATABASES
+
+    def test_is_active_for_user_respects_everyone_on(self):
+        """
+        Test flag.is_active_for_user returns truthy value when everyone is set to True overriding all other settings.
+        """
+        flag = waffle.get_waffle_flag_model().objects.create(
+            name="feature_flag_name",
+            staff=False,
+            everyone=True,
+        )
+        staff_user = get_user_model()(
+            id=999,
+            username="foo",
+            is_staff=True,
+        )
+        self.assertTrue(flag.is_active_for_user(staff_user))
+
+    def test_is_active_for_user_respects_everyone_off(self):
+        """
+        Test flag.is_active_for_user returns falsy value when everyone is set to False overriding all other settings.
+        """
+        flag = waffle.get_waffle_flag_model().objects.create(
+            name="feature_flag_name",
+            staff=True,
+            everyone=False,
+        )
+        staff_user = get_user_model()(
+            id=999,
+            username="foo",
+            is_staff=True,
+        )
+        self.assertFalse(flag.is_active_for_user(staff_user))


### PR DESCRIPTION
Currently, if I read the documents correctly, it reads that `everyone` setting/config. for a waffle flag should override all the other settings when set to `True` (i.e. 'Yes') or `False` (i.e. 'No'), but current version of the code contradicts this.

I have added the testcase `WaffleFlagEveryoneSettingTests` to confirm that is the case. 
Solution was to update the method `is_active_for_user` to also consider the case where `everyone` is set to `False`.

Raising this PR to fix the issue. Any questions, please let me know.

