### PR TITLE
Update the docs with explicit unittest to clarify usage of flag attribute everyone

### DIFF
--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -51,6 +51,7 @@ Jinja Templates
 ---------------
 
 .. versionchanged:: 0.19
+
 If you are using Jinja2 templates, the ``django-jinja`` dependency is currently
 unavailable with django 3.0 and greater; 2.x versions are compatible as well as 1.11.
 

--- a/docs/types/flag.rst
+++ b/docs/types/flag.rst
@@ -46,8 +46,11 @@ Flags can be administered through the Django `admin site`_ or the
 :name:
     The name of the flag. Will be used to identify the flag everywhere.
 :everyone:
-    Globally set the Flag, **overriding all other criteria**. Leave as
+    **INCORRECT:** Globally set the Flag, **overriding all other criteria**. Leave as
     *Unknown* to use other criteria.
+
+    **CORRECT:** Globally set the Flag when set to *Yes*, **overriding all other criteria**. Leave as
+    *Unknown* or *No* to use other criteria.
 :testing:
     Can the flag be specified via a querystring parameter? :ref:`See
     below <types-flag-testing>`.

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -230,8 +230,9 @@ class AbstractBaseFlag(BaseModel):
         return flush_keys
 
     def is_active_for_user(self, user: AbstractBaseUser) -> bool | None:
-        if self.everyone:
-            return True
+        # According to the docs, everyone should override all the other settings
+        if self.everyone is not None:
+            return self.everyone
 
         if self.authenticated and user.is_authenticated:
             return True

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -230,9 +230,8 @@ class AbstractBaseFlag(BaseModel):
         return flush_keys
 
     def is_active_for_user(self, user: AbstractBaseUser) -> bool | None:
-        # According to the docs, everyone should override all the other settings
-        if self.everyone is not None:
-            return self.everyone
+        if self.everyone:
+            return True
 
         if self.authenticated and user.is_authenticated:
             return True

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -803,3 +803,39 @@ class FunctionTests(TestCase):
         response = process_request(request, views.flag_in_view_readonly)
         assert 'dwf_myflag' not in response.cookies
         self.assertEqual(b'off', response.content)
+
+
+class WaffleFlagEveryoneSettingTests(TestCase):
+    databases = DATABASES
+
+    def test_is_active_for_user_respects_everyone_on(self):
+        """
+        Test flag.is_active_for_user returns truthy value when everyone is set to True overriding all other settings.
+        """
+        flag = waffle.get_waffle_flag_model().objects.create(
+            name="feature_flag_name",
+            staff=False,
+            everyone=True,
+        )
+        staff_user = get_user_model()(
+            id=999,
+            username="foo",
+            is_staff=True,
+        )
+        self.assertTrue(flag.is_active_for_user(staff_user))
+
+    def test_is_active_for_user_respects_everyone_off(self):
+        """
+        Test flag.is_active_for_user returns falsy value when everyone is set to False overriding all other settings.
+        """
+        flag = waffle.get_waffle_flag_model().objects.create(
+            name="feature_flag_name",
+            staff=True,
+            everyone=False,
+        )
+        staff_user = get_user_model()(
+            id=999,
+            username="foo",
+            is_staff=True,
+        )
+        self.assertFalse(flag.is_active_for_user(staff_user))

--- a/waffle/tests/test_waffle.py
+++ b/waffle/tests/test_waffle.py
@@ -803,39 +803,3 @@ class FunctionTests(TestCase):
         response = process_request(request, views.flag_in_view_readonly)
         assert 'dwf_myflag' not in response.cookies
         self.assertEqual(b'off', response.content)
-
-
-class WaffleFlagEveryoneSettingTests(TestCase):
-    databases = DATABASES
-
-    def test_is_active_for_user_respects_everyone_on(self):
-        """
-        Test flag.is_active_for_user returns truthy value when everyone is set to True overriding all other settings.
-        """
-        flag = waffle.get_waffle_flag_model().objects.create(
-            name="feature_flag_name",
-            staff=False,
-            everyone=True,
-        )
-        staff_user = get_user_model()(
-            id=999,
-            username="foo",
-            is_staff=True,
-        )
-        self.assertTrue(flag.is_active_for_user(staff_user))
-
-    def test_is_active_for_user_respects_everyone_off(self):
-        """
-        Test flag.is_active_for_user returns falsy value when everyone is set to False overriding all other settings.
-        """
-        flag = waffle.get_waffle_flag_model().objects.create(
-            name="feature_flag_name",
-            staff=True,
-            everyone=False,
-        )
-        staff_user = get_user_model()(
-            id=999,
-            username="foo",
-            is_staff=True,
-        )
-        self.assertFalse(flag.is_active_for_user(staff_user))


### PR DESCRIPTION
For more context, please refer to #561.
Basically, current version of the docs incorrectly suggests that setting waffle flag attribute `everyone` overrides all the other setting unless set to `Unknown` (i.e. `None`).

![image](https://github.com/user-attachments/assets/814dd714-5edf-492f-a7c8-89f98faf38c6)

Proposed changes in this PR:
1.  [Fixes the docs re: incorrect usage of the waffle flag attribute everyone.](https://github.com/jazzband/django-waffle/commit/3eb921dbcf8bf20056ea9e45dd5963508969efb7)
2. [Adds testcase WaffleFlagEveryoneSettingTests to prevent breaking changes and makes the behaviour explicit](https://github.com/jazzband/django-waffle/commit/9cbb40b89c8a554031d7594ecefbc77921a32b32)
3. [Fixes the warning - "django-waffle/docs/starting/installation.rst:54: WARNING: Explicit markup ends without a blank line; unexpected unindent."](https://github.com/jazzband/django-waffle/commit/98a40692e24f4eb81203e2171e6f1e45ae1e4ac1)