### PR TITLE
Dropped support for Python 3.8 and Django 5.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.8, 3.9, '3.10', 3.11, 3.12, 3.13 ]
+        python-version: [ 3.9, '3.10', 3.11, 3.12, 3.13 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -32,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["django>=4.2"]
 [project.optional-dependencies]
 docs = ["sphinx", "sphinx-rtd-theme"]
@@ -55,7 +53,7 @@ namespaces = false
 waffle = ["py.typed"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.13"
 exclude = "waffle/tests"
 disallow_incomplete_defs = true
 disallow_untyped_calls = true
@@ -68,7 +66,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py38"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ namespaces = false
 waffle = ["py.typed"]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.9"
 exclude = "waffle/tests"
 disallow_incomplete_defs = true
 disallow_untyped_calls = true
@@ -66,7 +66,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py313"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist =
-    py{38,39}-django{42}
-    py{310}-django{42,50,51,52}
-    py{311}-django{42,50,51,52}
-    py{312}-django{42,50,51,52}
+    py{39}-django{42}
+    py{310}-django{42,51,52}
+    py{311}-django{42,51,52}
+    py{312}-django{42,51,52}
     py{313}-django{51,52}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
@@ -20,7 +19,6 @@ python =
 allowlist_externals = ./run.sh
 deps =
 	django42: Django>=4.2,<4.3
-	django50: Django>=5.0,<5.1
 	django51: Django>=5.1,<5.2
 	django52: Django>=5.1,<5.3
 	djangomain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Both Python 3.8 and Django 5.0 have reached EOL, so are no longer supported by this package.