### PR TITLE
Remove support for EOL Django 5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     py{39}-django{42}
-    py{310}-django{42,50,51,52}
-    py{311}-django{42,50,51,52}
-    py{312}-django{42,50,51,52}
+    py{310}-django{42,51,52}
+    py{311}-django{42,51,52}
+    py{312}-django{42,51,52}
     py{313}-django{51,52}
 isolated_build = True
 
@@ -19,7 +19,6 @@ python =
 allowlist_externals = ./run.sh
 deps =
 	django42: Django>=4.2,<4.3
-	django50: Django>=5.0,<5.1
 	django51: Django>=5.1,<5.2
 	django52: Django>=5.1,<5.3
 	djangomain: https://github.com/django/django/archive/main.tar.gz
@@ -29,7 +28,7 @@ commands =
 
 [testenv:i18n]
 deps =
-	Django>=4.2,<5.3
+	Django>=4.2,<5.3,!=5.0.*
 	-r{toxinidir}/requirements.txt
 commands =
     ./run.sh makemessages


### PR DESCRIPTION
https://endoflife.date/django

![CleanShot 2025-06-14 at 17 39 25@2x](https://github.com/user-attachments/assets/03416d58-75f9-4d9c-869b-59b905d0f6ad)
