### PR TITLE
lint: ignore specific imports on linting

### DIFF
--- a/waffle/apps.py
+++ b/waffle/apps.py
@@ -7,4 +7,4 @@ class WaffleConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'
 
     def ready(self) -> None:
-        import waffle.signals  # noqa: F401
+        import waffle.signals  # noqa: F401,PLC0415

--- a/waffle/managers.py
+++ b/waffle/managers.py
@@ -6,7 +6,7 @@ from waffle.utils import get_setting, get_cache
 
 
 if TYPE_CHECKING:
-    from waffle.models import _BaseModelType, AbstractBaseFlag, AbstractBaseSample, AbstractBaseSwitch  # noqa: F401
+    from waffle.models import _BaseModelType, AbstractBaseFlag, AbstractBaseSample, AbstractBaseSwitch  # noqa: F401,PLC0415
 else:
     _BaseModelType = TypeVar("_BaseModelType")
 


### PR DESCRIPTION
Not sure why the linter suddenly broke but these imports cannot be placed at the top of the file - they are deliberately imported later.