### PR TITLE
Fix: is_active_for_user should be False when everyone is false even if users or groups are added

### DIFF
--- a/docs/types/flag.rst
+++ b/docs/types/flag.rst
@@ -55,18 +55,18 @@ Flags can be administered through the Django `admin site`_ or the
     A percentage of users for whom the flag will be active, if no other
     criteria applies to them.
 :superusers:
-    Is this flag always active for superusers?
+    Is this flag active for superusers?
 :staff:
-    Is this flag always active for staff?
+    Is this flag active for staff?
 :authenticated:
-    Is this flag always active for authenticated users?
+    Is this flag active for authenticated users?
 :languages:
     Is the ``LANGUAGE_CODE`` of the request in this list?
     (Comma-separated values.)
 :groups:
-    A list of group IDs for which this flag will always be active.
+    A list of group IDs for which this flag is active.
 :users:
-    A list of user IDs for which this flag will always be active.
+    A list of user IDs for which this flag is active.
 :rollout:
     Activate Rollout mode? :ref:`See below <types-flag-rollout>`.
 :note:

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -401,7 +401,7 @@ class AbstractUserFlag(AbstractBaseFlag):
 
     def is_active_for_user(self, user: AbstractBaseUser) -> bool | None:
         is_active = super().is_active_for_user(user)
-        if is_active:
+        if is_active is not None:
             return is_active
 
         user_ids = self._get_user_ids()


### PR DESCRIPTION
Make the "everyone" setting override all other settings including if a user or group is specifically added to the flag through .user or .groups.

Relates to https://github.com/django-waffle/django-waffle/pull/561 but fixes the issue if "everyone" is used in addition to adding users or groups to the `.users` or `.groups` set of a user-based flag. 

I'm not sure if this counts as a "breaking" change – it seems like it gets to completely fixing the behavior that was fixed in 561 but for flags that target users and groups (not just the staff, superuser, etc. settings)