### PR TITLE
Fix migrations to work with swapped models

### DIFF
--- a/waffle/migrations/0001_initial.py
+++ b/waffle/migrations/0001_initial.py
@@ -31,6 +31,7 @@ class Migration(migrations.Migration):
                 ('users', models.ManyToManyField(help_text='Activate this flag for these users.', to=settings.AUTH_USER_MODEL, blank=True)),
             ],
             options={
+                'swappable': 'WAFFLE_FLAG_MODEL',
             },
             bases=(models.Model,),
         ),
@@ -45,6 +46,7 @@ class Migration(migrations.Migration):
                 ('modified', models.DateTimeField(default=django.utils.timezone.now, help_text='Date when this Sample was last modified.')),
             ],
             options={
+                'swappable': 'WAFFLE_SAMPLE_MODEL',
             },
             bases=(models.Model,),
         ),
@@ -60,6 +62,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'verbose_name_plural': 'Switches',
+                'swappable': 'WAFFLE_SWITCH_MODEL',
             },
             bases=(models.Model,),
         ),

--- a/waffle/migrations/0003_update_strings_for_i18n.py
+++ b/waffle/migrations/0003_update_strings_for_i18n.py
@@ -14,15 +14,27 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterModelOptions(
             name='flag',
-            options={'verbose_name': 'Flag', 'verbose_name_plural': 'Flags'},
+            options={
+                'verbose_name': 'Flag',
+                'verbose_name_plural': 'Flags',
+                'swappable': 'WAFFLE_FLAG_MODEL',
+            },
         ),
         migrations.AlterModelOptions(
             name='sample',
-            options={'verbose_name': 'Sample', 'verbose_name_plural': 'Samples'},
+            options={
+                'verbose_name': 'Sample',
+                'verbose_name_plural': 'Samples',
+                'swappable': 'WAFFLE_SAMPLE_MODEL',
+            },
         ),
         migrations.AlterModelOptions(
             name='switch',
-            options={'verbose_name': 'Switch', 'verbose_name_plural': 'Switches'},
+            options={
+                'verbose_name': 'Switch',
+                'verbose_name_plural': 'Switches',
+                'swappable': 'WAFFLE_SWITCH_MODEL',
+            },
         ),
         migrations.AlterField(
             model_name='flag',


### PR DESCRIPTION
When using the swappable models in django-waffle, the migrations for `waffle` still create the default models (`Flag`, `Sample`, `Switch`).
As far as I understand, it is because the migrations were generated before they were marked as `swappable`. 

I **think** this is backwards compatible: if you don't use `WAFFLE_*_MODEL` nothing changes; if you use it, it was already broken (and you probably had a different workaround?)

FYI, the workaround we currently use is to set `MIGRATION_MODULES` in settings and use these modified migrations.
