### PR TITLE
fix: coverage exclude tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ namespaces = false
 [tool.setuptools.package-data]
 waffle = ["py.typed"]
 
+[tool.coverage.run]
+source = ["waffle"]
+omit = ["waffle/tests/*"]
+
 [tool.mypy]
 python_version = "3.9"
 exclude = "waffle/tests"


### PR DESCRIPTION
Not sure if I'm just confused, but while working on #586 I noticed the coverage is also counted on the tests themselves, which does not make sense to me. So small suggestion for adjusting pyproject.toml...