### PR TITLE
tests: make middleware tests discoverable by Django test runner

### DIFF
--- a/waffle/tests/test_middleware.py
+++ b/waffle/tests/test_middleware.py
@@ -1,49 +1,48 @@
 from django.http import HttpResponse
-from django.test import RequestFactory
+from django.test import RequestFactory, TestCase
 
 from waffle.middleware import WaffleMiddleware
 
+class MiddlewareTests(TestCase):
+    def setUp(self):
+        self.request = RequestFactory().get('/foo')
+        self.middleware = WaffleMiddleware(lambda request: HttpResponse())
 
-get = RequestFactory().get('/foo')
+    def test_set_cookies(self):
+        self.request.waffles = {'foo': [True, False], 'bar': [False, False]}
+        resp = HttpResponse()
+        assert 'dwf_foo' not in resp.cookies
+        assert 'dwf_bar' not in resp.cookies
 
+        resp = self.middleware.process_response(self.request, resp)
+        assert 'dwf_foo' in resp.cookies
+        assert 'dwf_bar' in resp.cookies
 
-def test_set_cookies():
-    get.waffles = {'foo': [True, False], 'bar': [False, False]}
-    resp = HttpResponse()
-    assert 'dwf_foo' not in resp.cookies
-    assert 'dwf_bar' not in resp.cookies
+        assert 'True' == resp.cookies['dwf_foo'].value
+        assert 'False' == resp.cookies['dwf_bar'].value
 
-    resp = WaffleMiddleware().process_response(get, resp)
-    assert 'dwf_foo' in resp.cookies
-    assert 'dwf_bar' in resp.cookies
+    def test_rollout_cookies(self):
+        self.request.waffles = {'foo': [True, True],
+                                'bar': [False, True],
+                                'baz': [True, False],
+                                'qux': [False, False]}
+        resp = HttpResponse()
+        resp = self.middleware.process_response(self.request, resp)
+        for k in self.request.waffles:
+            cookie = f'dwf_{k}'
+            assert cookie in resp.cookies
+            assert str(self.request.waffles[k][0]) == resp.cookies[cookie].value
+            if self.request.waffles[k][1]:
+                assert bool(resp.cookies[cookie]['max-age']) == self.request.waffles[k][0]
+            else:
+                assert resp.cookies[cookie]['max-age']
 
-    assert 'True' == resp.cookies['dwf_foo'].value
-    assert 'False' == resp.cookies['dwf_bar'].value
-
-
-def test_rollout_cookies():
-    get.waffles = {'foo': [True, True],
-                   'bar': [False, True],
-                   'baz': [True, False],
-                   'qux': [False, False]}
-    resp = HttpResponse()
-    resp = WaffleMiddleware().process_response(get, resp)
-    for k in get.waffles:
-        cookie = f'dwf_{k}'
-        assert cookie in resp.cookies
-        assert str(get.waffles[k][0]) == resp.cookies[cookie].value
-        if get.waffles[k][1]:
-            assert bool(resp.cookies[cookie]['max-age']) == get.waffles[k][0]
-        else:
-            assert resp.cookies[cookie]['max-age']
-
-
-def test_testing_cookies():
-    get.waffles = {}
-    get.waffle_tests = {'foo': True, 'bar': False}
-    resp = HttpResponse()
-    resp = WaffleMiddleware().process_response(get, resp)
-    for k in get.waffle_tests:
-        cookie = f'dwft_{k}'
-        assert str(get.waffle_tests[k]) == resp.cookies[cookie].value
-        assert not resp.cookies[cookie]['max-age']
+    def test_testing_cookies(self):
+        self.request.waffles = {}
+        self.request.waffle_tests = {'foo': True, 'bar': False}
+        resp = HttpResponse()
+        resp = self.middleware.process_response(self.request, resp)
+        for k in self.request.waffle_tests:
+            cookie = f'dwft_{k}'
+            assert str(self.request.waffle_tests[k]) == resp.cookies[cookie].value
+            assert not resp.cookies[cookie]['max-age']


### PR DESCRIPTION
Again I'm not sure whether I'm missing something obvious, but the middleware tests in the project were just plain functions and not run by CI. CI uses django test runner since apparently swtiching from nose about 10+ years ago, so it did not run these tests, but not sure here since I'm not that familiar with nose and so on.

Personally I would switch to pytest + pytest-django, but this PR is the simpler change for now. Let me know if pytest sounds better, then I'm open to doing a follow up for that. In any case keeping the test style consistent makes sense, even with pytest.

Since `MiddlewareMixin` does require `get_response` by now, I had to change that as well. (Also see linked MR which modernized the middleware as well).