### PR TITLE
Prefetch flag users/groups to prevent N+1 queries

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -90,11 +90,15 @@ class BaseModel(models.Model):
         return objs
 
     @classmethod
-    def get_all_from_db(cls: type[_BaseModelType]) -> list[_BaseModelType]:
+    def _get_all_queryset(cls: type[_BaseModelType]) -> models.QuerySet[_BaseModelType]:
         objects = cls.objects
         if get_setting('READ_FROM_WRITE_DB'):
             objects = objects.using(router.db_for_write(cls))
-        return list(objects.all())
+        return objects.all()
+
+    @classmethod
+    def get_all_from_db(cls: type[_BaseModelType]) -> list[_BaseModelType]:
+        return list(cls._get_all_queryset())
 
     def flush(self) -> None:
         cache = get_cache()
@@ -364,6 +368,10 @@ class AbstractUserFlag(AbstractBaseFlag):
             keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), self.name),
         ])
         return flush_keys
+
+    @classmethod
+    def get_all_from_db(cls: type[_BaseModelType]) -> list[_BaseModelType]:
+        return list(cls._get_all_queryset().prefetch_related('users', 'groups'))
 
     def _get_user_ids(self) -> set[Any]:
         cache = get_cache()

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -373,39 +373,28 @@ class AbstractUserFlag(AbstractBaseFlag):
     def get_all_from_db(cls: type[_BaseModelType]) -> list[_BaseModelType]:
         return list(cls._get_all_queryset().prefetch_related('users', 'groups'))
 
-    def _get_user_ids(self) -> set[Any]:
+    def _get_relation_ids(self, relation: Any, cache_key_setting: str) -> set[Any]:
         cache = get_cache()
-        cache_key = keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), self.name)
+        cache_key = keyfmt(get_setting(cache_key_setting), self.name)
         cached = cache.get(cache_key)
         if cached == CACHE_EMPTY:
             return set()
         if cached:
             return cached
 
-        user_ids = set(self.users.all().values_list('pk', flat=True))
-        if not user_ids:
+        ids = {obj.pk for obj in relation.all()}
+        if not ids:
             cache.add(cache_key, CACHE_EMPTY)
             return set()
 
-        cache.add(cache_key, user_ids)
-        return user_ids
+        cache.add(cache_key, ids)
+        return ids
+
+    def _get_user_ids(self) -> set[Any]:
+        return self._get_relation_ids(self.users, 'FLAG_USERS_CACHE_KEY')
 
     def _get_group_ids(self) -> set[Any]:
-        cache = get_cache()
-        cache_key = keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), self.name)
-        cached = cache.get(cache_key)
-        if cached == CACHE_EMPTY:
-            return set()
-        if cached:
-            return cached
-
-        group_ids = set(self.groups.all().values_list('pk', flat=True))
-        if not group_ids:
-            cache.add(cache_key, CACHE_EMPTY)
-            return set()
-
-        cache.add(cache_key, group_ids)
-        return group_ids
+        return self._get_relation_ids(self.groups, 'FLAG_GROUPS_CACHE_KEY')
 
     def is_active_for_user(self, user: AbstractBaseUser) -> bool | None:
         is_active = super().is_active_for_user(user)

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -90,11 +90,15 @@ class BaseModel(models.Model):
         return objs
 
     @classmethod
-    def get_all_from_db(cls: type[_BaseModelType]) -> list[_BaseModelType]:
+    def _get_all_queryset(cls: type[_BaseModelType]) -> models.QuerySet[_BaseModelType]:
         objects = cls.objects
         if get_setting('READ_FROM_WRITE_DB'):
             objects = objects.using(router.db_for_write(cls))
-        return list(objects.all())
+        return objects.all()
+
+    @classmethod
+    def get_all_from_db(cls: type[_BaseModelType]) -> list[_BaseModelType]:
+        return list(cls._get_all_queryset())
 
     def flush(self) -> None:
         cache = get_cache()
@@ -369,69 +373,55 @@ class AbstractUserFlag(AbstractBaseFlag):
         return flush_keys
 
     @classmethod
+    def _get_all_queryset(cls: type[_BaseModelType]) -> models.QuerySet[_BaseModelType]:
+        return super()._get_all_queryset().prefetch_related('users', 'groups')
+
+    @classmethod
     def get_all(cls):
         flags = super().get_all()
-        prefetched = cls._prefetch_user_group_ids(flags)
-        for flag in flags:
-            for attr, val in prefetched.get(flag.name, {}).items():
-                setattr(flag, attr, val)
+        cls._prefetch_user_group_ids(flags)
         return flags
 
     @classmethod
-    def _prefetch_user_group_ids(cls, flags: list) -> dict[str, dict[str, set]]:
+    def _prefetch_user_group_ids(cls, flags: list) -> None:
         if not flags:
-            return {}
+            return
         cache = get_cache()
-        user_key_fmt = get_setting('FLAG_USERS_CACHE_KEY')
-        group_key_fmt = get_setting('FLAG_GROUPS_CACHE_KEY')
-        user_keys = [keyfmt(user_key_fmt, f.name) for f in flags]
-        group_keys = [keyfmt(group_key_fmt, f.name) for f in flags]
+        user_keys = [keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), f.name) for f in flags]
+        group_keys = [keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), f.name) for f in flags]
         cached = cache.get_many(user_keys + group_keys)
-        result: dict[str, dict[str, set]] = {}
         for keys, attr in [(user_keys, '_prefetched_user_ids'), (group_keys, '_prefetched_group_ids')]:
             for flag, key in zip(flags, keys):
                 if key in cached:
                     val = cached[key]
-                    result.setdefault(flag.name, {})[attr] = set() if val == CACHE_EMPTY else val
-        return result
+                    setattr(flag, attr, set() if val == CACHE_EMPTY else val)
+
+    def _get_relation_ids(self, relation: Any, cache_key_setting: str) -> set[Any]:
+        cache = get_cache()
+        cache_key = keyfmt(get_setting(cache_key_setting), self.name)
+        cached = cache.get(cache_key)
+        if cached == CACHE_EMPTY:
+            return set()
+        if cached:
+            return cached
+
+        ids = {obj.pk for obj in relation.all()}
+        if not ids:
+            cache.add(cache_key, CACHE_EMPTY)
+            return set()
+
+        cache.add(cache_key, ids)
+        return ids
 
     def _get_user_ids(self) -> set[Any]:
         if self._prefetched_user_ids is not None:
             return self._prefetched_user_ids
-        cache = get_cache()
-        cache_key = keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), self.name)
-        cached = cache.get(cache_key)
-        if cached == CACHE_EMPTY:
-            return set()
-        if cached:
-            return cached
-
-        user_ids = set(self.users.all().values_list('pk', flat=True))
-        if not user_ids:
-            cache.add(cache_key, CACHE_EMPTY)
-            return set()
-
-        cache.add(cache_key, user_ids)
-        return user_ids
+        return self._get_relation_ids(self.users, 'FLAG_USERS_CACHE_KEY')
 
     def _get_group_ids(self) -> set[Any]:
         if self._prefetched_group_ids is not None:
             return self._prefetched_group_ids
-        cache = get_cache()
-        cache_key = keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), self.name)
-        cached = cache.get(cache_key)
-        if cached == CACHE_EMPTY:
-            return set()
-        if cached:
-            return cached
-
-        group_ids = set(self.groups.all().values_list('pk', flat=True))
-        if not group_ids:
-            cache.add(cache_key, CACHE_EMPTY)
-            return set()
-
-        cache.add(cache_key, group_ids)
-        return group_ids
+        return self._get_relation_ids(self.groups, 'FLAG_GROUPS_CACHE_KEY')
 
     def is_active_for_user(self, user: AbstractBaseUser) -> bool | None:
         is_active = super().is_active_for_user(user)

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -65,6 +65,25 @@ class ModelsTests(TestCase):
             list(flags[0].users.all())
             list(flags[0].groups.all())
 
+    def test_flag_get_all_from_db_get_user_group_ids_no_extra_queries(self):
+        """_get_user_ids / _get_group_ids must use the prefetch cache, not re-query."""
+        Flag = get_waffle_flag_model()
+        flag = Flag.objects.create(name='test-flag')
+        user = User.objects.create_user(username='waffle-user')
+        group = Group.objects.create(name='waffle-group')
+        flag.users.add(user)
+        flag.groups.add(group)
+
+        flags = Flag.get_all_from_db()
+        self.assertEqual(len(flags), 1)
+
+        with self.assertNumQueries(0):
+            user_ids = flags[0]._get_user_ids()
+            group_ids = flags[0]._get_group_ids()
+
+        self.assertEqual(user_ids, {user.pk})
+        self.assertEqual(group_ids, {group.pk})
+
     def test_flag_get_all_prefetch_survives_cache(self):
         Flag = get_waffle_flag_model()
         flag = Flag.objects.create(name='test-flag')
@@ -81,8 +100,11 @@ class ModelsTests(TestCase):
         self.assertEqual(len(flags), 1)
 
         with self.assertNumQueries(0):
-            list(flags[0].users.all())
-            list(flags[0].groups.all())
+            user_ids = flags[0]._get_user_ids()
+            group_ids = flags[0]._get_group_ids()
+
+        self.assertEqual(user_ids, {user.pk})
+        self.assertEqual(group_ids, {group.pk})
 
     def test_switch_get_all_from_db_returns_list(self):
         Switch = get_waffle_switch_model()

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -1,3 +1,5 @@
+from django.contrib.auth.models import Group, User
+from django.db import models
 from django.test import TestCase
 
 from waffle import (
@@ -5,7 +7,6 @@ from waffle import (
     get_waffle_sample_model,
     get_waffle_switch_model,
 )
-from django.contrib.auth.models import User
 
 
 class ModelsTests(TestCase):
@@ -36,3 +37,63 @@ class ModelsTests(TestCase):
         flag = get_waffle_flag_model().objects.create(name='test-flag')
         flag.everyone = True
         self.assertEqual(flag.is_active_for_user(User()), True)
+
+    def test_get_all_queryset_returns_queryset(self):
+        Flag = get_waffle_flag_model()
+        Flag.objects.create(name='test-flag')
+        self.assertIsInstance(Flag._get_all_queryset(), models.QuerySet)
+
+    def test_get_all_from_db_returns_list(self):
+        Flag = get_waffle_flag_model()
+        Flag.objects.create(name='test-flag')
+        result = Flag.get_all_from_db()
+        self.assertIsInstance(result, list)
+
+    def test_flag_get_all_from_db_prefetches_users_and_groups(self):
+        Flag = get_waffle_flag_model()
+        flag = Flag.objects.create(name='test-flag')
+        user = User.objects.create_user(username='waffle-user')
+        group = Group.objects.create(name='waffle-group')
+        flag.users.add(user)
+        flag.groups.add(group)
+
+        flags = Flag.get_all_from_db()
+        self.assertEqual(len(flags), 1)
+
+        # users and groups should already be cached — no extra queries needed
+        with self.assertNumQueries(0):
+            list(flags[0].users.all())
+            list(flags[0].groups.all())
+
+    def test_flag_get_all_prefetch_survives_cache(self):
+        Flag = get_waffle_flag_model()
+        flag = Flag.objects.create(name='test-flag')
+        user = User.objects.create_user(username='waffle-user')
+        group = Group.objects.create(name='waffle-group')
+        flag.users.add(user)
+        flag.groups.add(group)
+
+        # Warm the cache via get_all()
+        Flag.get_all()
+
+        # Second call hits the cache; prefetch data must survive serialization
+        flags = Flag.get_all()
+        self.assertEqual(len(flags), 1)
+
+        with self.assertNumQueries(0):
+            list(flags[0].users.all())
+            list(flags[0].groups.all())
+
+    def test_switch_get_all_from_db_returns_list(self):
+        Switch = get_waffle_switch_model()
+        Switch.objects.create(name='test-switch')
+        result = Switch.get_all_from_db()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+
+    def test_sample_get_all_from_db_returns_list(self):
+        Sample = get_waffle_sample_model()
+        Sample.objects.create(name='test-sample', percent=50)
+        result = Sample.get_all_from_db()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.contrib.auth.models import Group, User
+from django.db import models
 from django.test import TestCase
 
 from waffle import (
@@ -40,6 +41,88 @@ class ModelsTests(TestCase):
         flag = get_waffle_flag_model().objects.create(name='test-flag')
         flag.everyone = True
         self.assertEqual(flag.is_active_for_user(User()), True)
+
+    def test_get_all_queryset_returns_queryset(self):
+        Flag = get_waffle_flag_model()
+        Flag.objects.create(name='test-flag')
+        self.assertIsInstance(Flag._get_all_queryset(), models.QuerySet)
+
+    def test_get_all_from_db_returns_list(self):
+        Flag = get_waffle_flag_model()
+        Flag.objects.create(name='test-flag')
+        result = Flag.get_all_from_db()
+        self.assertIsInstance(result, list)
+
+    def test_flag_get_all_from_db_prefetches_users_and_groups(self):
+        Flag = get_waffle_flag_model()
+        flag = Flag.objects.create(name='test-flag')
+        user = User.objects.create_user(username='waffle-user')
+        group = Group.objects.create(name='waffle-group')
+        flag.users.add(user)
+        flag.groups.add(group)
+
+        flags = Flag.get_all_from_db()
+        self.assertEqual(len(flags), 1)
+
+        # users and groups should already be cached — no extra queries needed
+        with self.assertNumQueries(0):
+            list(flags[0].users.all())
+            list(flags[0].groups.all())
+
+    def test_flag_get_all_from_db_get_user_group_ids_no_extra_queries(self):
+        """_get_user_ids / _get_group_ids must use the prefetch cache, not re-query."""
+        Flag = get_waffle_flag_model()
+        flag = Flag.objects.create(name='test-flag')
+        user = User.objects.create_user(username='waffle-user')
+        group = Group.objects.create(name='waffle-group')
+        flag.users.add(user)
+        flag.groups.add(group)
+
+        flags = Flag.get_all_from_db()
+        self.assertEqual(len(flags), 1)
+
+        with self.assertNumQueries(0):
+            user_ids = flags[0]._get_user_ids()
+            group_ids = flags[0]._get_group_ids()
+
+        self.assertEqual(user_ids, {user.pk})
+        self.assertEqual(group_ids, {group.pk})
+
+    def test_flag_get_all_prefetch_survives_cache(self):
+        Flag = get_waffle_flag_model()
+        flag = Flag.objects.create(name='test-flag')
+        user = User.objects.create_user(username='waffle-user')
+        group = Group.objects.create(name='waffle-group')
+        flag.users.add(user)
+        flag.groups.add(group)
+
+        # Warm the cache via get_all()
+        Flag.get_all()
+
+        # Second call hits the cache; prefetch data must survive serialization
+        flags = Flag.get_all()
+        self.assertEqual(len(flags), 1)
+
+        with self.assertNumQueries(0):
+            user_ids = flags[0]._get_user_ids()
+            group_ids = flags[0]._get_group_ids()
+
+        self.assertEqual(user_ids, {user.pk})
+        self.assertEqual(group_ids, {group.pk})
+
+    def test_switch_get_all_from_db_returns_list(self):
+        Switch = get_waffle_switch_model()
+        Switch.objects.create(name='test-switch')
+        result = Switch.get_all_from_db()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+
+    def test_sample_get_all_from_db_returns_list(self):
+        Sample = get_waffle_sample_model()
+        Sample.objects.create(name='test-sample', percent=50)
+        result = Sample.get_all_from_db()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
 
 
 class GetAllPrefetchTests(TestCase):


### PR DESCRIPTION
# Why

When `get_all()` loads flags from the database, it previously fetched each flag without prefetching the `users` and `groups` M2M relations. Any subsequent access to those relations — such as checking whether a flag is active for a given user or group — fired two additional queries per flag, producing an N+1 pattern that scaled with the number of flags.

# What

- Extract `_get_all_queryset` from `BaseModel.get_all_from_db` so subclasses can augment the queryset before it is materialised.
- Override `_get_all_queryset` on `AbstractUserFlag` to add `prefetch_related('users', 'groups')`, collapsing the per-flag M2M queries into two bulk queries regardless of flag count.
- Override `get_all` on `AbstractUserFlag` to batch-fetch the user and group waffle cache keys for all flags in a single `cache.get_many` call, and stamp each flag instance with `_prefetched_user_ids` / `_prefetched_group_ids` so that `_get_user_ids()` and `_get_group_ids()` return immediately on subsequent calls without touching the cache again.
- Merge the duplicated `_get_user_ids` / `_get_group_ids` cache-miss bodies into a shared `_get_relation_ids` helper.

# Testing

Tests assert that after `get_all_from_db`, accessing `.users` and `.groups` on flag instances requires zero additional queries. Further tests confirm that `_get_user_ids()` and `_get_group_ids()` also require zero queries when called on prefetched flags, that `_prefetch_user_group_ids` issues exactly one `cache.get_many` call regardless of flag count, and that the `CACHE_EMPTY` sentinel is handled correctly.