### PR TITLE
Batch-fetch user/group cache keys in get_all() to fix N+1

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -352,6 +352,9 @@ class AbstractUserFlag(AbstractBaseFlag):
         verbose_name=_('Users'),
     )
 
+    _prefetched_user_ids: set | None = None
+    _prefetched_group_ids: set | None = None
+
     class Meta(AbstractBaseFlag.Meta):
         abstract = True
         verbose_name = _('Flag')
@@ -365,7 +368,36 @@ class AbstractUserFlag(AbstractBaseFlag):
         ])
         return flush_keys
 
+    @classmethod
+    def get_all(cls):
+        flags = super().get_all()
+        prefetched = cls._prefetch_user_group_ids(flags)
+        for flag in flags:
+            for attr, val in prefetched.get(flag.name, {}).items():
+                setattr(flag, attr, val)
+        return flags
+
+    @classmethod
+    def _prefetch_user_group_ids(cls, flags: list) -> dict[str, dict[str, set]]:
+        if not flags:
+            return {}
+        cache = get_cache()
+        user_key_fmt = get_setting('FLAG_USERS_CACHE_KEY')
+        group_key_fmt = get_setting('FLAG_GROUPS_CACHE_KEY')
+        user_keys = [keyfmt(user_key_fmt, f.name) for f in flags]
+        group_keys = [keyfmt(group_key_fmt, f.name) for f in flags]
+        cached = cache.get_many(user_keys + group_keys)
+        result: dict[str, dict[str, set]] = {}
+        for keys, attr in [(user_keys, '_prefetched_user_ids'), (group_keys, '_prefetched_group_ids')]:
+            for flag, key in zip(flags, keys):
+                if key in cached:
+                    val = cached[key]
+                    result.setdefault(flag.name, {})[attr] = set() if val == CACHE_EMPTY else val
+        return result
+
     def _get_user_ids(self) -> set[Any]:
+        if self._prefetched_user_ids is not None:
+            return self._prefetched_user_ids
         cache = get_cache()
         cache_key = keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), self.name)
         cached = cache.get(cache_key)
@@ -383,6 +415,8 @@ class AbstractUserFlag(AbstractBaseFlag):
         return user_ids
 
     def _get_group_ids(self) -> set[Any]:
+        if self._prefetched_group_ids is not None:
+            return self._prefetched_group_ids
         cache = get_cache()
         cache_key = keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), self.name)
         cached = cache.get(cache_key)

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+from django.contrib.auth.models import Group, User
 from django.test import TestCase
 
 from waffle import (
@@ -5,7 +8,8 @@ from waffle import (
     get_waffle_sample_model,
     get_waffle_switch_model,
 )
-from django.contrib.auth.models import User
+from waffle.models import CACHE_EMPTY
+from waffle.utils import get_cache, get_setting, keyfmt
 
 
 class ModelsTests(TestCase):
@@ -36,3 +40,107 @@ class ModelsTests(TestCase):
         flag = get_waffle_flag_model().objects.create(name='test-flag')
         flag.everyone = True
         self.assertEqual(flag.is_active_for_user(User()), True)
+
+
+class GetAllPrefetchTests(TestCase):
+    """Tests for the N+1 fix: get_all() batch-fetches user/group cache keys."""
+
+    def setUp(self):
+        super().setUp()
+        get_cache().clear()
+
+    def _user_cache_key(self, flag_name):
+        return keyfmt(get_setting('FLAG_USERS_CACHE_KEY'), flag_name)
+
+    def _group_cache_key(self, flag_name):
+        return keyfmt(get_setting('FLAG_GROUPS_CACHE_KEY'), flag_name)
+
+    def test_get_all_prefetches_ids_from_cache(self):
+        """After get_all(), _get_user_ids() and _get_group_ids() return correct ids without extra cache gets."""
+        Flag = get_waffle_flag_model()
+        user = User.objects.create_user(username='alice')
+        group = Group.objects.create(name='editors')
+        flag = Flag.objects.create(name='flag-a')
+        flag.users.add(user)
+        flag.groups.add(group)
+
+        cache = get_cache()
+        cache.set(self._user_cache_key('flag-a'), {user.pk})
+        cache.set(self._group_cache_key('flag-a'), {group.pk})
+
+        flags = Flag.get_all()
+        self.assertEqual(len(flags), 1)
+
+        with mock.patch.object(cache, 'get', wraps=cache.get) as spy:
+            user_result = flags[0]._get_user_ids()
+            group_result = flags[0]._get_group_ids()
+            spy.assert_not_called()
+        self.assertIn(user.pk, user_result)
+        self.assertIn(group.pk, group_result)
+
+    def test_get_all_prefetch_uses_get_many_not_individual_gets(self):
+        """_prefetch_user_group_ids issues one cache.get_many call, not N individual gets."""
+        Flag = get_waffle_flag_model()
+        Flag.objects.create(name='flag-x')
+        Flag.objects.create(name='flag-y')
+
+        cache = get_cache()
+        with mock.patch.object(cache, 'get_many', wraps=cache.get_many) as spy:
+            Flag._prefetch_user_group_ids(Flag.objects.all())
+            self.assertEqual(spy.call_count, 1)
+            # Called with keys for both flags (users + groups = 4 keys total)
+            called_keys = spy.call_args[0][0]
+            self.assertEqual(len(called_keys), 4)
+
+    def test_prefetched_ids_used_by_getters(self):
+        """_get_user_ids() and _get_group_ids() return prefetched values without hitting the cache."""
+        Flag = get_waffle_flag_model()
+        flag = Flag.objects.create(name='flag-c')
+        flag._prefetched_user_ids = {42, 99}
+        flag._prefetched_group_ids = {7}
+
+        cache = get_cache()
+        with mock.patch.object(cache, 'get', wraps=cache.get) as spy:
+            user_result = flag._get_user_ids()
+            group_result = flag._get_group_ids()
+            spy.assert_not_called()
+
+        self.assertEqual(user_result, {42, 99})
+        self.assertEqual(group_result, {7})
+
+    def test_prefetch_empty_cache_skips_attribute(self):
+        """When a flag's user/group keys are absent from cache, no prefetch attribute is set."""
+        Flag = get_waffle_flag_model()
+        Flag.objects.create(name='flag-e')
+
+        # Don't prime the cache — keys are absent.
+        cache = get_cache()
+        cache.clear()
+
+        flags = Flag.get_all()
+        self.assertEqual(len(flags), 1)
+        self.assertIsNone(flags[0]._prefetched_user_ids)
+        self.assertIsNone(flags[0]._prefetched_group_ids)
+
+    def test_prefetch_cache_empty_sentinel_yields_empty_set(self):
+        """A CACHE_EMPTY sentinel in cache means no users/groups; attribute is an empty set."""
+        Flag = get_waffle_flag_model()
+        Flag.objects.create(name='flag-f')
+
+        cache = get_cache()
+        cache.set(self._user_cache_key('flag-f'), CACHE_EMPTY)
+        cache.set(self._group_cache_key('flag-f'), CACHE_EMPTY)
+        cache.delete(get_setting(Flag.ALL_CACHE_KEY))
+
+        flags = Flag.get_all()
+        self.assertEqual(len(flags), 1)
+        self.assertEqual(flags[0]._prefetched_user_ids, set())
+        self.assertEqual(flags[0]._prefetched_group_ids, set())
+
+    def test_prefetch_empty_flags_list_is_no_op(self):
+        """_prefetch_user_group_ids with an empty list does nothing (no cache calls)."""
+        Flag = get_waffle_flag_model()
+        cache = get_cache()
+        with mock.patch.object(cache, 'get_many', wraps=cache.get_many) as spy:
+            Flag._prefetch_user_group_ids([])
+            spy.assert_not_called()


### PR DESCRIPTION
## Why

`waffle_json` (used by the `GET /feature_flags/waffle_status` endpoint) calls `get_all()` to load all flags, then evaluates each flag's user and group membership for the requesting user. Each of those evaluations triggered an individual `cache.get()` call — one for user IDs and one for group IDs per flag. On a deployment with many flags this produced an N+1 cache query pattern that was caught in Datadog.

## What

Override `get_all()` on `AbstractUserFlag` to batch-fetch all user and group cache keys in a single `cache.get_many()` call immediately after the flags are loaded. The results are stored on two new instance attributes (`_prefetched_user_ids`, `_prefetched_group_ids`). `_get_user_ids()` and `_get_group_ids()` short-circuit to return those values when present, skipping the per-flag cache lookup entirely.

Flags whose keys are absent from cache leave the attributes as `None`, so the existing individual-fetch fallback path is still reached (e.g. when a flag's cache entry hasn't been warmed yet). The `CACHE_EMPTY` sentinel is handled the same way it is in the existing code — it maps to an empty set.

## Testing

Six new tests cover the prefetch behaviour:

- Correct user and group IDs are returned after `get_all()` without any additional `cache.get()` calls
- The prefetch issues exactly one `cache.get_many()` call regardless of the number of flags, with the correct number of keys
- Setting `_prefetched_*` directly on a flag instance is respected by the getters (no cache hit)
- Flags with absent cache keys are left with `None` attributes (fallback path preserved)
- A `CACHE_EMPTY` sentinel in the cache yields an empty set on the attribute
- An empty flags list results in zero `cache.get_many()` calls