### PR TITLE
Warm cold user/group caches in get_all()

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -388,11 +388,23 @@ class AbstractUserFlag(AbstractBaseFlag):
         group_keys = [keyfmt(group_key_fmt, f.name) for f in flags]
         cached = cache.get_many(user_keys + group_keys)
         result: dict[str, dict[str, set]] = {}
-        for keys, attr in [(user_keys, '_prefetched_user_ids'), (group_keys, '_prefetched_group_ids')]:
+        to_cache: dict[str, Any] = {}
+        for keys, attr, relation in [
+            (user_keys, '_prefetched_user_ids', 'users'),
+            (group_keys, '_prefetched_group_ids', 'groups'),
+        ]:
             for flag, key in zip(flags, keys):
                 if key in cached:
                     val = cached[key]
                     result.setdefault(flag.name, {})[attr] = set() if val == CACHE_EMPTY else val
+                elif flag.everyone is None:
+                    # everyone True/False short-circuits is_active before the
+                    # membership check, so only warm flags where it's unset.
+                    ids = set(getattr(flag, relation).all().values_list('pk', flat=True))
+                    result.setdefault(flag.name, {})[attr] = ids
+                    to_cache[key] = ids if ids else CACHE_EMPTY
+        if to_cache:
+            cache.set_many(to_cache)
         return result
 
     def _get_user_ids(self) -> set[Any]:

--- a/waffle/tests/test_models.py
+++ b/waffle/tests/test_models.py
@@ -108,17 +108,44 @@ class GetAllPrefetchTests(TestCase):
         self.assertEqual(user_result, {42, 99})
         self.assertEqual(group_result, {7})
 
-    def test_prefetch_empty_cache_skips_attribute(self):
-        """When a flag's user/group keys are absent from cache, no prefetch attribute is set."""
+    def test_prefetch_warms_cold_cache_with_single_set_many(self):
+        """Cold user/group keys are warmed via one set_many(), not per-flag adds."""
         Flag = get_waffle_flag_model()
-        Flag.objects.create(name='flag-e')
+        user = User.objects.create_user(username='bob')
+        group = Group.objects.create(name='writers')
+        flag_a = Flag.objects.create(name='flag-e')
+        flag_a.users.add(user)
+        flag_a.groups.add(group)
+        Flag.objects.create(name='flag-g')  # no users/groups
 
-        # Don't prime the cache — keys are absent.
+        # Don't prime the per-flag caches — keys are absent.
         cache = get_cache()
         cache.clear()
 
-        flags = Flag.get_all()
-        self.assertEqual(len(flags), 1)
+        with mock.patch.object(cache, 'set_many', wraps=cache.set_many) as set_spy:
+            flags = Flag.get_all()
+            self.assertEqual(set_spy.call_count, 1)
+
+        flags = {f.name: f for f in flags}
+        self.assertEqual(flags['flag-e']._prefetched_user_ids, {user.pk})
+        self.assertEqual(flags['flag-e']._prefetched_group_ids, {group.pk})
+        # A flag with no members warms to an empty set (CACHE_EMPTY in cache).
+        self.assertEqual(flags['flag-g']._prefetched_user_ids, set())
+        self.assertEqual(flags['flag-g']._prefetched_group_ids, set())
+        self.assertEqual(cache.get(self._user_cache_key('flag-g')), CACHE_EMPTY)
+
+    def test_prefetch_skips_warming_flags_with_everyone_set(self):
+        """Flags with `everyone` set never need membership ids, so they aren't warmed."""
+        Flag = get_waffle_flag_model()
+        Flag.objects.create(name='flag-everyone', everyone=True)
+
+        cache = get_cache()
+        cache.clear()
+
+        with mock.patch.object(cache, 'set_many', wraps=cache.set_many) as set_spy:
+            flags = Flag.get_all()
+            set_spy.assert_not_called()
+
         self.assertIsNone(flags[0]._prefetched_user_ids)
         self.assertIsNone(flags[0]._prefetched_group_ids)
 


### PR DESCRIPTION
## Why

Thanks to #591 - the latency on the waffle view has greatly improved. The p50-p95 stats are much lower and stable. Looking at p99, p99.9, and Max stats - there is some room for improvement. 

<img width="427" height="256" alt="great latency stats" src="https://github.com/user-attachments/assets/1af0e4ee-d1fd-4e45-9ce7-f10e03ce81d9" />

<img width="417" height="259" alt="not so great latency stats" src="https://github.com/user-attachments/assets/daece361-d1e6-436e-8030-95636e7978d1" />


The N+1 fix in https://github.com/django-waffle/django-waffle/pull/591 batches the per-flag user/group cache reads, but on a cold cache it leaves the missing keys unpopulated. Every flag whose keys are absent still falls back to a per-flag DB query later in `is_active`, so the first request after a cache flush pays the full N+1 cost. 

## What

When a flag's user/group key is missing from the batched `cache.get_many()`, fetch its membership ids and stage them, then write all warmed keys back with a single `cache.set_many()`. Flags with `everyone` set are skipped, since `is_active` short-circuits before the membership check and never needs those ids.

## Testing

- Added a test asserting cold keys are warmed via exactly one `set_many()` call, including the empty-membership case (`CACHE_EMPTY`).
- Added a test asserting flags with `everyone` set are not warmed.
- `./run.sh test waffle.tests.test_models` — 188 passed.


----

As a side note, I think https://github.com/django-waffle/django-waffle/pull/590 would also have a measurable impact